### PR TITLE
docs: add issue workflow and docs/ branch convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,8 @@ You are an AI collaborator on hotdog-racing.com. Before writing any code or maki
 ## Git Strategy
 
 - **Branching:** One feature branch per meaningful piece of work. Branch from `main`, merge back via PR.
-- **Naming:** `feat/` for new features and pages, `fix/` for bugs, `chore/` for maintenance, `content/` for content-only changes (blog posts, events, sponsors).
-  - Examples: `feat/global-layout`, `feat/home-page`, `content/first-blog-post`, `fix/nav-mobile`
+- **Naming:** `feat/` for new features and pages, `fix/` for bugs, `chore/` for maintenance, `content/` for content-only changes (blog posts, events, sponsors), `docs/` for documentation and workflow changes (no issue required).
+  - Examples: `feat/global-layout`, `feat/home-page`, `content/first-blog-post`, `fix/nav-mobile`, `docs/issue-workflow`
 - **Merging:** Check the Vercel preview URL on the PR. If it looks right, merge. No formal review process needed.
 - **Commits:** Descriptive, present-tense messages. One logical change per commit where possible.
 - `main` is protected — all changes go through PRs, no direct pushes.
@@ -67,6 +67,10 @@ When adding a new tool or dependency that produces build output or local config,
 - Keep dependencies minimal; review what any new package does before adding it.
 
 ## Agent skills
+
+### Issue workflow
+
+The standard process for triaging and implementing issues is documented in `docs/agents/issue-workflow.md`. Read this before starting any issue work.
 
 ### Issue tracker
 

--- a/docs/agents/issue-workflow.md
+++ b/docs/agents/issue-workflow.md
@@ -1,0 +1,78 @@
+# Issue Workflow
+
+This is the standard workflow for working through GitHub issues on this project.
+
+## "Let's get started"
+
+When the user says they want to get started (or similar), run through these steps:
+
+1. Run `/triage` on all open `needs-triage` issues — evaluate each against `docs/site-prd.md` and assign the appropriate label (`ready-for-agent`, `ready-for-human`, `needs-info`, `wontfix`) with a brief comment explaining the reasoning.
+2. Present a summary of label changes.
+3. Identify the next issue to work on: the lowest-numbered `ready-for-agent` issue whose "Blocked by" dependencies are all closed.
+4. Announce the chosen issue and begin.
+
+## Working an issue
+
+### 1. Read the issue
+
+```
+gh issue view <number> --comments
+```
+
+Check the "Blocked by" section. If any blocker is still open, skip this issue and pick the next unblocked one.
+
+### 2. Check for a spec
+
+Tool issues (anything under `app/tools/`) require a spec at `docs/[tool-name]-spec.md` before implementation. If it doesn't exist, stop and ask the user to run `/to-prd` to create one.
+
+### 3. Check scope
+
+If the issue feels too large for a single PR, stop before touching any code. Propose a breakdown and offer to run `/to-issues`. Wait for the user's go-ahead before proceeding.
+
+### 4. Read relevant source files
+
+Explore the codebase as needed to understand what exists before writing anything.
+
+### 5. Create a branch
+
+Follow the git strategy in `CLAUDE.md`. Branch from `main` using the appropriate prefix (`feat/`, `fix/`, `chore/`, `content/`).
+
+### 6. Implement
+
+Follow the coding principles and project structure conventions in `CLAUDE.md`.
+
+### 7. Run checks
+
+```
+tsc --noEmit
+npm run lint
+```
+
+If anything in `lib/` was added or modified:
+
+```
+npx vitest run
+```
+
+Fix all errors before continuing.
+
+### 8. Post a verification checklist
+
+Ask the user to review the changes before committing. The checklist should include:
+
+- Each acceptance criterion from the issue, formatted as a checkbox
+- Any edge cases worth verifying manually
+
+For any issue involving interactive UI or mobile layout, include this command to spin up a local production server (avoids the WebSocket HMR interference from `next dev` that breaks touch events on mobile):
+
+```
+npm run build && npm start
+```
+
+Then access it from a mobile device at `http://<your-local-ip>:3000`. To find your local IP run `ipconfig` and look for the IPv4 address under your active network adapter.
+
+Wait for the user's approval before proceeding.
+
+### 9. Commit and open a PR
+
+Once the user approves, commit the changes and open a PR referencing the issue (e.g. `Closes #10`). The PR description should include what was built and any notable decisions. The Vercel preview URL will be available on the PR for final visual verification.


### PR DESCRIPTION
## Summary

- Adds `docs/agents/issue-workflow.md` documenting the step-by-step process Claude follows when triaging and implementing GitHub issues
- Adds `docs/` as an explicit branch prefix convention for workflow/documentation changes that don't require a GitHub issue
- References the workflow doc from `CLAUDE.md` so new sessions pick it up automatically

## Notes

The workflow doc covers: triage → pick next unblocked issue → read spec → check scope → implement → checks → verification checklist (with mobile prod server workaround) → wait for approval → commit + PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)