### PR TITLE
feat: coming soon mode

### DIFF
--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Coming Soon | Hotdog Racing',
+  description: 'RC drift setup tools and content. Launching soon.',
+}
+
+export default function ComingSoonPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-near-black px-6 text-center">
+      <p className="mb-4 font-mono text-xs tracking-[0.3em] text-accent uppercase">
+        Coming Soon
+      </p>
+      <h1 className="mb-4 text-5xl font-bold tracking-tight text-near-white sm:text-7xl">
+        HOTDOG<span className="text-accent">RACING</span>
+      </h1>
+      <p className="mb-10 max-w-sm text-base text-near-white/60">
+        Setup tools and content for RC drift. Something worth waiting for.
+      </p>
+      <a
+        href="https://www.instagram.com/hotdogracingus"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-mono text-sm text-accent transition-colors hover:text-accent-700"
+      >
+        @hotdogracingus →
+      </a>
+    </div>
+  )
+}

--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 
 export default function ComingSoonPage() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-near-black px-6 text-center">
+    <div className="fixed inset-0 z-999 flex flex-col items-center justify-center bg-near-black px-6 text-center">
       <p className="mb-4 font-mono text-xs tracking-[0.3em] text-accent uppercase">
         Coming Soon
       </p>

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,7 +4,7 @@ const BYPASS_COOKIE = 'hr_preview'
 const COMING_SOON_PATH = '/coming-soon'
 
 export function middleware(req: NextRequest) {
-  if (process.env.COMING_SOON !== 'true') return NextResponse.next()
+  if (process.env.COMING_SOON !== 'true' || process.env.VERCEL_ENV !== 'production') return NextResponse.next()
 
   const { pathname } = req.nextUrl
 
@@ -15,6 +15,8 @@ export function middleware(req: NextRequest) {
     const res = NextResponse.redirect(new URL('/', req.url))
     res.cookies.set(BYPASS_COOKIE, '1', {
       httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24 * 7,
     })

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BYPASS_COOKIE = 'hr_preview'
+const COMING_SOON_PATH = '/coming-soon'
+
+export function middleware(req: NextRequest) {
+  if (process.env.COMING_SOON !== 'true') return NextResponse.next()
+
+  const { pathname } = req.nextUrl
+
+  if (pathname === COMING_SOON_PATH) return NextResponse.next()
+
+  const previewParam = req.nextUrl.searchParams.get('preview')
+  if (previewParam && previewParam === process.env.PREVIEW_SECRET) {
+    const res = NextResponse.redirect(new URL('/', req.url))
+    res.cookies.set(BYPASS_COOKIE, '1', {
+      httpOnly: true,
+      path: '/',
+      maxAge: 60 * 60 * 24 * 7,
+    })
+    return res
+  }
+
+  if (req.cookies.get(BYPASS_COOKIE)?.value === '1') return NextResponse.next()
+
+  return NextResponse.redirect(new URL(COMING_SOON_PATH, req.url))
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|svg|gif|webp)$).*)'],
+}


### PR DESCRIPTION
## Summary
- `middleware.ts` intercepts all requests when `COMING_SOON=true` (production env only) and redirects to `/coming-soon`
- `/coming-soon` — branded holding page with Instagram link
- Bypass: visiting `/?preview=<PREVIEW_SECRET>` sets a 7-day cookie that skips the redirect
- PR preview URLs are unaffected (env var is production-only)

## Vercel setup (already done)
- `COMING_SOON=true` — Production only
- `PREVIEW_SECRET=<secret>` — Production only
- Redeploy triggered after adding env vars

## Test plan
- [x] `hotdog-racing.com` redirects to coming soon page
- [x] Coming soon page looks correct in dark mode (it has no light/dark toggle — intentional)
- [x] `hotdog-racing.com/?preview=<secret>` redirects to home and shows real site
- [x] Revisiting `hotdog-racing.com` after bypass still shows real site (cookie persists)
- [x] PR preview URLs show the real site without any redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)