### PR TITLE
docs: require needs-triage label on all new issues

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -15,7 +15,7 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 
 ## When a skill says "publish to the issue tracker"
 
-Create a GitHub issue.
+Create a GitHub issue. Always apply the `needs-triage` label so the issue enters the normal triage flow — this is required whether the issue is created by a skill or manually. If you encounter an open issue that is missing a triage label entirely, apply `needs-triage` before acting on it.
 
 ## When a skill says "fetch the relevant ticket"
 


### PR DESCRIPTION
## Summary
- Clarifies that `needs-triage` must always be applied to newly created issues, regardless of whether they were created by a skill or manually on GitHub
- Adds instruction for agents to apply `needs-triage` to any open issue found without a triage label before acting on it

Prompted by issue #25 being created without a triage label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)