### PR TITLE
docs: replace boilerplate README with project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,52 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Hotdog Racing
 
-## Getting Started
+Setup tools and content for RC drift — [hotdog-racing.com](https://hotdog-racing.com).
 
-First, run the development server:
+## Pages
+
+| Route | Purpose |
+|---|---|
+| `/` | Home |
+| `/tools` | Interactive setup tools landing page |
+| `/tools/suspension` | Suspension Alignment Visualizer |
+| `/tools/esc` | ESC Settings Visualizer |
+| `/tools/gyro` | Servo & Gyro Visualizer (stub) |
+| `/events` | Competition schedule |
+| `/blog` | Guides and posts |
+| `/podcast` | Episode list |
+| `/about` | Background and build specs |
+
+## Stack
+
+Next.js (App Router) · TypeScript · Tailwind CSS · Vercel
+
+## Local development
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Checks
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npx tsc --noEmit    # type check
+npm run lint         # ESLint
+npx vitest run       # unit tests (lib/ only)
+```
 
-## Learn More
+## Structure
 
-To learn more about Next.js, take a look at the following resources:
+```
+app/             # Next.js App Router pages
+components/      # Shared UI components
+lib/             # Pure functions — tool logic, math, parsers
+content/posts/   # Blog posts as Markdown with frontmatter
+docs/            # PRD, tool specs, agent workflow docs
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Deployment
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Vercel — every push to `main` triggers a production deploy. Every PR gets a preview URL. No workflow file needed.


### PR DESCRIPTION
Replaces the default create-next-app README with an accurate project overview: page inventory, stack, local dev commands, project structure, and deployment notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)