### PR TITLE
feat: sponsors static config and home page section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import Sponsors from '@/components/Sponsors'
 
 export default function Home() {
   return (
@@ -178,14 +179,7 @@ function SponsorsSection() {
     <section className="py-20 px-6" style={{ background: 'var(--surface)' }}>
       <div className="mx-auto max-w-7xl">
         <SectionHeader label="Partners" title="Sponsors" />
-        <div
-          className="mt-10 flex min-h-24 items-center justify-center rounded-lg border"
-          style={{ borderColor: 'var(--border)', background: 'var(--surface-2)' }}
-        >
-          <p className="font-mono text-sm" style={{ color: 'var(--muted)' }}>
-            — Sponsors coming soon —
-          </p>
-        </div>
+        <Sponsors />
       </div>
     </section>
   )

--- a/components/Sponsors.tsx
+++ b/components/Sponsors.tsx
@@ -1,0 +1,36 @@
+import { sponsors } from '@/lib/sponsors/config'
+
+export default function Sponsors() {
+  return (
+    <div className="mt-10 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+      {sponsors.map(sponsor => (
+        <a
+          key={sponsor.name}
+          href={sponsor.siteUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex flex-col items-center justify-center gap-3 rounded-lg border p-6 transition-colors hover:border-accent"
+          style={{ borderColor: 'var(--border)', background: 'var(--surface-2)' }}
+        >
+          {sponsor.logoUrl ? (
+            <img
+              src={sponsor.logoUrl}
+              alt={sponsor.name}
+              className="h-12 w-auto object-contain"
+            />
+          ) : (
+            <div
+              className="flex h-12 w-12 items-center justify-center rounded font-mono text-lg font-bold"
+              style={{ background: 'var(--surface)', color: 'var(--muted)' }}
+            >
+              {sponsor.name.charAt(0)}
+            </div>
+          )}
+          <span className="text-center text-sm font-medium" style={{ color: 'var(--foreground)' }}>
+            {sponsor.name}
+          </span>
+        </a>
+      ))}
+    </div>
+  )
+}

--- a/lib/sponsors/config.ts
+++ b/lib/sponsors/config.ts
@@ -1,0 +1,18 @@
+export type Sponsor = {
+  name: string
+  logoUrl: string
+  siteUrl: string
+}
+
+export const sponsors: Sponsor[] = [
+  {
+    name: 'Sponsor One',
+    logoUrl: '',
+    siteUrl: 'https://example.com',
+  },
+  {
+    name: 'Sponsor Two',
+    logoUrl: '',
+    siteUrl: 'https://example.com',
+  },
+]


### PR DESCRIPTION
## Summary

- `lib/sponsors/config.ts` — typed `Sponsor` array with two placeholder entries; real logos/data swapped in via a future `content/` branch
- `components/Sponsors.tsx` — responsive logo grid (2→3→4 col), letter-initial fallback when `logoUrl` is empty, `target="_blank" rel="noopener noreferrer"` on each link
- `app/page.tsx` — replaces the "Sponsors coming soon" placeholder with `<Sponsors />`

Component is exported and ready to be imported by `/about` (that wiring is #7's responsibility).

## Test plan

- [x] Sponsors section renders on the home page (no "coming soon" placeholder)
- [x] Each card shows the letter-initial fallback and sponsor name
- [x] Cards open `siteUrl` in a new tab
- [x] Grid is responsive: 2 col mobile → 3 sm → 4 lg
- [x] Dark/light mode renders correctly

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)