### PR TITLE
chore: extract about page data to lib/about/config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ You are an AI collaborator on hotdog-racing.com. Before writing any code or maki
 - No comments unless the WHY is non-obvious — well-named identifiers are self-documenting.
 - No extra abstractions, error handling, or features beyond what the task requires.
 - Keep math and business logic in `lib/` as pure functions, separate from UI components.
+- Keep structured data (static arrays of records) in `lib/[domain]/config.ts`, not inline in page or component files. Pages import and render; they don't define data.
 - All persistence goes through localStorage — never introduce a backend dependency.
 
 ## Project Structure Conventions

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Image from 'next/image'
+import { resumeEntries, buildSpecs, partners } from '@/lib/about/config'
 
 export const metadata: Metadata = {
   title: 'About',
@@ -109,52 +110,6 @@ function BackgroundSection() {
   )
 }
 
-type ResumeEntry = {
-  year: string
-  series: string
-  result: string
-  detail?: string
-}
-
-const resumeEntries: ResumeEntry[] = [
-  {
-    year: '2025',
-    series: 'Drift-PDX SDC Oregon Series',
-    result: '1st Overall',
-    detail: '3 round wins, 1 second place, 1 TQ',
-  },
-  {
-    year: '2025',
-    series: 'SDC World Finals',
-    result: 'Top 32',
-    detail: 'Qualified 22nd overall',
-  },
-  {
-    year: '2024',
-    series: 'Protek PDX Underground Drift Series',
-    result: '3rd Overall',
-    detail: '2 podium finishes',
-  },
-  {
-    year: '2024',
-    series: 'PDX Underground Tandem Tuesday Series',
-    result: '1st Overall',
-    detail: '2 round wins',
-  },
-  {
-    year: '2024',
-    series: 'PDX Underground SDC Oregon Series',
-    result: '2nd Overall',
-    detail: '2 round wins, 1 TQ',
-  },
-  {
-    year: '2024',
-    series: 'SDC World Finals',
-    result: 'Top 48',
-    detail: 'Qualified 39th overall',
-  },
-]
-
 function DriftResumeSection() {
   return (
     <section className="py-20 px-6" style={{ background: 'var(--surface)' }}>
@@ -192,21 +147,6 @@ function DriftResumeSection() {
   )
 }
 
-type SpecRow = { label: string; value: string }
-
-const buildSpecs: SpecRow[] = [
-  { label: 'Chassis', value: 'Yokomo MD 3.0' },
-  {label: 'Hardware', value: '1up Pro Duty Titanium Screws/Bearings/Turnbuckles'},
-  { label: 'ESC', value: 'Acuvance Xarvis XX' },
-  { label: 'Motor', value: 'Acuvance Agile 10.5 / LV45 Rotor' },
-  { label: 'Capacitor', value: 'Acuvance Blaze' },
-  { label: 'Servo', value: 'Futaba CD-700' },
-  { label: 'Gyro', value: 'Futaba GYD-550' },
-  { label: 'Receiver', value: 'Futaba R404SBS-E' },
-  { label: 'Transmitter', value: 'Futaba 10-PX' },
-  { label: 'Competition Body', value: 'ReveD GR Corolla' },
-]
-
 function CurrentBuildSection() {
   return (
     <section className="py-20 px-6">
@@ -238,16 +178,6 @@ function CurrentBuildSection() {
     </section>
   )
 }
-
-const partners = [
-  {name: 'Drift-PDX', handle: '@drift_pdx', url: 'https://www.instagram.com/drift_pdx/'},
-  {name: 'Team Yokomo', handle: '@official_yokomo', url: 'https://www.instagram.com/official_yokomo/'},
-  {name: 'Acuvance', handle: '@acuvance_usa', url: 'https://www.instagram.com/acuvance_usa/'},
-  { name: '1UP Racing', handle: '@1up_racing', url: 'https://www.instagram.com/1up_racing/' },
-  { name: 'SP Designs RC', handle: '@spdesignsrc', url: 'https://www.instagram.com/spdesignsrc/' },
-  { name: 'Team PDX', handle: '@teampdxrcdrift', url: 'https://www.instagram.com/teampdxrcdrift/' },
-  { name: 'Team D-Style', handle: '@team_d_style', url: 'https://www.instagram.com/team_d_style/' },
-]
 
 function PartnersSection() {
   return (

--- a/lib/about/config.ts
+++ b/lib/about/config.ts
@@ -1,0 +1,79 @@
+export type ResumeEntry = {
+  year: string
+  series: string
+  result: string
+  detail?: string
+}
+
+export const resumeEntries: ResumeEntry[] = [
+  {
+    year: '2025',
+    series: 'Drift-PDX SDC Oregon Series',
+    result: '1st Overall',
+    detail: '3 round wins, 1 second place, 1 TQ',
+  },
+  {
+    year: '2025',
+    series: 'SDC World Finals',
+    result: 'Top 32',
+    detail: 'Qualified 22nd overall',
+  },
+  {
+    year: '2024',
+    series: 'Protek PDX Underground Drift Series',
+    result: '3rd Overall',
+    detail: '2 podium finishes',
+  },
+  {
+    year: '2024',
+    series: 'PDX Underground Tandem Tuesday Series',
+    result: '1st Overall',
+    detail: '2 round wins',
+  },
+  {
+    year: '2024',
+    series: 'PDX Underground SDC Oregon Series',
+    result: '2nd Overall',
+    detail: '2 round wins, 1 TQ',
+  },
+  {
+    year: '2024',
+    series: 'SDC World Finals',
+    result: 'Top 48',
+    detail: 'Qualified 39th overall',
+  },
+]
+
+export type SpecRow = {
+  label: string
+  value: string
+}
+
+export const buildSpecs: SpecRow[] = [
+  { label: 'Chassis', value: 'Yokomo MD 3.0' },
+  { label: 'Hardware', value: '1up Pro Duty Titanium Screws/Bearings/Turnbuckles' },
+  { label: 'ESC', value: 'Acuvance Xarvis XX' },
+  { label: 'Motor', value: 'Acuvance Agile 10.5 / LV45 Rotor' },
+  { label: 'Capacitor', value: 'Acuvance Blaze' },
+  { label: 'Servo', value: 'Futaba CD-700' },
+  { label: 'Gyro', value: 'Futaba GYD-550' },
+  { label: 'Receiver', value: 'Futaba R404SBS-E' },
+  { label: 'Transmitter', value: 'Futaba 10-PX' },
+  { label: 'Competition Body', value: 'ReveD GR Corolla' },
+]
+
+export type Partner = {
+  name: string
+  handle: string
+  url: string
+}
+
+export const partners: Partner[] = [
+  { name: 'Drift-PDX', handle: '@drift_pdx', url: 'https://www.instagram.com/drift_pdx/' },
+  { name: 'Team Yokomo', handle: '@official_yokomo', url: 'https://www.instagram.com/official_yokomo/' },
+  { name: 'Acuvance', handle: '@acuvance_usa', url: 'https://www.instagram.com/acuvance_usa/' },
+  { name: '1UP Racing', handle: '@1up_racing', url: 'https://www.instagram.com/1up_racing/' },
+  { name: 'SP Designs RC', handle: '@spdesignsrc', url: 'https://www.instagram.com/spdesignsrc/' },
+  { name: 'Team PDX', handle: '@teampdxrcdrift', url: 'https://www.instagram.com/teampdxrcdrift/' },
+  { name: 'Team D-Style', handle: '@team_d_style', url: 'https://www.instagram.com/team_d_style/' },
+]


### PR DESCRIPTION
## Summary

- Moves `resumeEntries`, `buildSpecs`, and `partners` out of `app/about/page.tsx` and into `lib/about/config.ts` with explicit exported types
- `app/about/page.tsx` now imports and renders only — no inline data
- Adds one line to `CLAUDE.md` Coding Principles: structured data belongs in `lib/[domain]/config.ts`, not inline in page or component files

No behavior change — purely a content organization refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)