### PR TITLE
feat: podcast page and YouTube episode integration

### DIFF
--- a/app/podcast/page.tsx
+++ b/app/podcast/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next'
+import { fetchEpisodes } from '@/lib/youtube/fetch'
+
+export const metadata: Metadata = {
+  title: 'Podcast',
+  description: 'RC Drift Talk — weekly live stream covering events, tuning, and everything in the RC drift world.',
+  openGraph: {
+    title: 'Podcast | Hotdog Racing',
+    description: 'RC Drift Talk — weekly live stream covering events, tuning, and everything in the RC drift world.',
+    url: 'https://hotdog-racing.com/podcast',
+  },
+}
+
+export default async function PodcastPage() {
+  const episodes = await fetchEpisodes()
+
+  return (
+    <div className="py-20 px-6">
+      <div className="mx-auto max-w-7xl">
+        <p className="mb-1 font-mono text-xs tracking-[0.25em] text-accent uppercase">Podcast</p>
+        <h1 className="mb-10 text-3xl font-bold sm:text-4xl" style={{ color: 'var(--foreground)' }}>
+          RC Drift Talk
+        </h1>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {episodes.map(episode => (
+            <a
+              key={episode.id}
+              href={episode.videoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group overflow-hidden rounded-lg border transition-colors hover:border-accent"
+              style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={episode.thumbnailUrl}
+                alt={episode.title}
+                className="aspect-video w-full object-cover"
+              />
+              <div className="p-4">
+                <p className="mb-1 font-mono text-xs" style={{ color: 'var(--muted)' }}>
+                  {new Date(episode.publishedAt).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </p>
+                <h2
+                  className="line-clamp-2 text-sm font-semibold leading-snug group-hover:text-accent"
+                  style={{ color: 'var(--foreground)' }}
+                >
+                  {episode.title}
+                </h2>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/LatestEpisode.tsx
+++ b/components/LatestEpisode.tsx
@@ -1,0 +1,38 @@
+import type { Episode } from '@/lib/youtube/fetch'
+
+export default function LatestEpisode({ episode }: { episode: Episode }) {
+  return (
+    <a
+      href={episode.videoUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col overflow-hidden rounded-lg border transition-colors hover:border-accent sm:flex-row"
+      style={{ borderColor: 'var(--border)', background: 'var(--surface-2)' }}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={episode.thumbnailUrl}
+        alt={episode.title}
+        className="aspect-video w-full object-cover sm:w-72 sm:shrink-0"
+      />
+      <div className="flex flex-col justify-center p-5">
+        <p className="mb-2 font-mono text-xs" style={{ color: 'var(--muted)' }}>
+          {new Date(episode.publishedAt).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          })}
+        </p>
+        <h3
+          className="text-base font-semibold leading-snug group-hover:text-accent"
+          style={{ color: 'var(--foreground)' }}
+        >
+          {episode.title}
+        </h3>
+        <p className="mt-2 line-clamp-2 text-sm" style={{ color: 'var(--muted)' }}>
+          {episode.description}
+        </p>
+      </div>
+    </a>
+  )
+}

--- a/lib/youtube/fetch.ts
+++ b/lib/youtube/fetch.ts
@@ -1,0 +1,71 @@
+export type Episode = {
+  id: string
+  title: string
+  description: string
+  thumbnailUrl: string
+  publishedAt: string
+  videoUrl: string
+}
+
+type PlaylistItemsResponse = {
+  items: Array<{
+    snippet: {
+      title: string
+      description: string
+      publishedAt: string
+      thumbnails: {
+        default?: { url: string }
+        medium?: { url: string }
+        high?: { url: string }
+        maxres?: { url: string }
+      }
+      resourceId: {
+        videoId: string
+      }
+    }
+  }>
+}
+
+export async function fetchEpisodes(): Promise<Episode[]> {
+  const apiKey = process.env.YOUTUBE_API_KEY
+  if (!apiKey) {
+    throw new Error(
+      'YOUTUBE_API_KEY is not set. Add it to .env.local locally and to Vercel project settings.'
+    )
+  }
+
+  const playlistId = process.env.YOUTUBE_PLAYLIST_ID
+  if (!playlistId) {
+    throw new Error(
+      'YOUTUBE_PLAYLIST_ID is not set. Add it to .env.local locally and to Vercel project settings.'
+    )
+  }
+
+  const res = await fetch(
+    `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&playlistId=${playlistId}&maxResults=50&key=${apiKey}`,
+    { cache: 'force-cache' }
+  )
+  if (!res.ok) {
+    throw new Error(`YouTube playlistItems API failed: ${res.status} ${res.statusText}`)
+  }
+
+  const data = (await res.json()) as PlaylistItemsResponse
+
+  return (data.items ?? []).map(item => {
+    const s = item.snippet
+    const thumbnail =
+      s.thumbnails.maxres?.url ??
+      s.thumbnails.high?.url ??
+      s.thumbnails.medium?.url ??
+      s.thumbnails.default?.url ??
+      ''
+    return {
+      id: s.resourceId.videoId,
+      title: s.title,
+      description: s.description,
+      thumbnailUrl: thumbnail,
+      publishedAt: s.publishedAt,
+      videoUrl: `https://www.youtube.com/watch?v=${s.resourceId.videoId}`,
+    }
+  })
+}


### PR DESCRIPTION
## Summary

- `lib/youtube/fetch.ts` — typed `fetchEpisodes()` pulls from `YOUTUBE_PLAYLIST_ID` via YouTube Data API v3; build fails with a descriptive error if either `YOUTUBE_API_KEY` or `YOUTUBE_PLAYLIST_ID` is missing
- `app/podcast/page.tsx` — responsive episode grid (1→2→3 col) with thumbnails, titles, and dates; each card links to YouTube
- `components/LatestEpisode.tsx` — exported featured episode card for home page use in #14
- Playlist-based approach (not uploads playlist) so non-podcast uploads are excluded

## Human setup required
- `YOUTUBE_API_KEY` and `YOUTUBE_PLAYLIST_ID` must be set in `.env.local` locally and in Vercel project settings (Production + Preview) — already done ✓

## Test plan
- [ ] `/podcast` renders episode grid with thumbnails
- [ ] Episodes match the curated playlist only
- [ ] Cards link to YouTube in a new tab
- [ ] Responsive layout correct on mobile and desktop
- [ ] Dark/light mode correct

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)