### PR TITLE
feat: add InstagramEmbed component

### DIFF
--- a/components/InstagramEmbed.tsx
+++ b/components/InstagramEmbed.tsx
@@ -1,0 +1,14 @@
+import Script from 'next/script'
+
+export default function InstagramEmbed() {
+  return (
+    <>
+      <blockquote
+        className="instagram-media w-full"
+        data-instgrm-permalink="https://www.instagram.com/hotdogracingus/"
+        data-instgrm-version="14"
+      />
+      <Script src="https://www.instagram.com/embed.js" strategy="lazyOnload" />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `InstagramEmbed` component using Instagram's official profile embed widget
- Loads `embed.js` via `next/script` with `lazyOnload` — no impact on page load
- No API token, no expiry, no environment variables needed

## Notes
- Visual verification happens in #14 when the component is placed on the home page
- `tsc --noEmit` and `npm run lint` pass (pre-existing warning in `Sponsors.tsx` unrelated)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)