### PR TITLE
fix: revise ESC motor math model for physical accuracy

### DIFF
--- a/lib/esc/config.ts
+++ b/lib/esc/config.ts
@@ -10,6 +10,28 @@ export type SelectDef<T extends string | number> = {
   defaultValue: T
 }
 
+// Rotor variants — kvScale relative to LV30 (standard).
+// KV ∝ 1/flux, so stronger magnets lower KV and raise stall torque by the same factor.
+// Scale factors assume LV numbers are proportional to rotor flux; refine once real specs available.
+export type RotorVariant = 'lv30' | 'lv38' | 'lv42'
+
+export type RotorVariantDef = {
+  label: string
+  kvScale: number
+  description: string
+}
+
+export const ROTOR_VARIANTS: Record<RotorVariant, RotorVariantDef> = {
+  lv30: { label: 'LV30', kvScale: 1.000,     description: 'Standard' },
+  lv38: { label: 'LV38', kvScale: 30 / 38,   description: 'Mid torque' },
+  lv42: { label: 'LV42', kvScale: 30 / 42,   description: 'High torque' },
+}
+
+export const ROTOR_VARIANT: SelectDef<RotorVariant> = {
+  options: ['lv30', 'lv38', 'lv42'],
+  defaultValue: 'lv30',
+}
+
 // Timing tab
 export const MOTOR_TURN: SliderDef = { min: 4.5, max: 21.5, step: 0.5, defaultValue: 10.5 }
 export const MOTOR_CAN_TIMING: SliderDef = { min: 0, max: 30, step: 1, defaultValue: 0 }

--- a/lib/esc/model.test.ts
+++ b/lib/esc/model.test.ts
@@ -83,24 +83,15 @@ describe('torquePowerCurve', () => {
     boostEndRPM: 20000,
     turboTiming: 0,
     turboActive: false,
+    rotorKvScale: 1.0,
   }
 
   it('returns N+1 points', () => {
-    const pts = torquePowerCurve(baseParams, 200)
-    expect(pts).toHaveLength(201)
+    expect(torquePowerCurve(baseParams, 200)).toHaveLength(201)
   })
 
   it('first point starts at RPM 0', () => {
-    const pts = torquePowerCurve(baseParams)
-    expect(pts[0].rpm).toBe(0)
-  })
-
-  it('normalizes torque and power to 0–100 range', () => {
-    const pts = torquePowerCurve(baseParams)
-    const maxT = Math.max(...pts.map(p => p.torque))
-    const maxP = Math.max(...pts.map(p => p.power))
-    expect(maxT).toBeCloseTo(100, 5)
-    expect(maxP).toBeCloseTo(100, 5)
+    expect(torquePowerCurve(baseParams)[0].rpm).toBe(0)
   })
 
   it('all torque and power values are non-negative', () => {
@@ -111,6 +102,11 @@ describe('torquePowerCurve', () => {
     }
   })
 
+  it('stall torque is 100% at zero timing on LV30 (fixed reference baseline)', () => {
+    const pts = torquePowerCurve(baseParams)
+    expect(pts[0].torque).toBeCloseTo(100, 3)
+  })
+
   it('torque and power peaks occur at different RPM values', () => {
     const pts = torquePowerCurve(baseParams)
     const peakTorqueRPM = pts.reduce((best, p) => (p.torque > best.torque ? p : best)).rpm
@@ -118,42 +114,97 @@ describe('torquePowerCurve', () => {
     expect(peakPowerRPM).toBeGreaterThan(peakTorqueRPM)
   })
 
-  it('curve bends through boost zone — torque differs below vs above boostStartRPM when boost > 0', () => {
-    const withBoost = torquePowerCurve({
-      ...baseParams,
-      boostTiming: 30,
-      boostStartRPM: 5000,
-      boostEndRPM: 20000,
-    })
-    const noBoost = torquePowerCurve(baseParams)
+  it('peak power is ~100% at zero timing (fixed reference baseline)', () => {
+    const pts = torquePowerCurve(baseParams)
+    const maxP = Math.max(...pts.map(p => p.power))
+    expect(maxP).toBeCloseTo(100, 1)
+  })
 
-    // Above boost end RPM, withBoost should have a different (shifted) torque curve shape
+  describe('timing increases RPM and reduces stall torque', () => {
+    it('higher timing lowers stall torque below 100%', () => {
+      const highTiming = torquePowerCurve({ ...baseParams, motorCanTiming: 30, boostTiming: 10, turboTiming: 55, turboActive: true })
+      expect(highTiming[0].torque).toBeLessThan(100)
+    })
+
+    it('with real hardware settings stall torque reflects only active timing at RPM=0', () => {
+      // At RPM=0, boost hasn't ramped in (starts at 5000 RPM) — only can + turbo apply.
+      // theta = 30° + 0° + 55° = 85°; cos(85° × 0.75) = cos(63.75°) ≈ 0.442 → 44.2%
+      const pts = torquePowerCurve({ ...baseParams, motorCanTiming: 30, boostTiming: 10, turboTiming: 55, turboActive: true })
+      expect(pts[0].torque).toBeCloseTo(44.2, 0)
+    })
+
+    it('with real hardware settings (95°) peak RPM ceiling is ~100k', () => {
+      const pts = torquePowerCurve({ ...baseParams, motorCanTiming: 30, boostTiming: 10, turboTiming: 55, turboActive: true })
+      const lastNonZero = [...pts].reverse().find(p => p.torque > 0)!
+      expect(lastNonZero.rpm).toBeGreaterThan(90_000)
+      expect(lastNonZero.rpm).toBeLessThan(115_000)
+    })
+
+    it('peak power is conserved — timing redistributes power, does not create it', () => {
+      const noTiming = torquePowerCurve(baseParams)
+      const highTiming = torquePowerCurve({ ...baseParams, motorCanTiming: 30, boostTiming: 10, turboTiming: 55, turboActive: true })
+      const peakNoTiming = Math.max(...noTiming.map(p => p.power))
+      const peakHighTiming = Math.max(...highTiming.map(p => p.power))
+      // Both should peak near 100% — field weakening conserves max power
+      expect(peakNoTiming).toBeCloseTo(100, 1)
+      expect(peakHighTiming).toBeCloseTo(100, 1)
+    })
+
+    it('higher timing shifts peak power to a higher RPM', () => {
+      const noTiming = torquePowerCurve(baseParams)
+      const highTiming = torquePowerCurve({ ...baseParams, motorCanTiming: 30 })
+      const peakRPMNoTiming = noTiming.reduce((best, p) => (p.power > best.power ? p : best)).rpm
+      const peakRPMHighTiming = highTiming.reduce((best, p) => (p.power > best.power ? p : best)).rpm
+      expect(peakRPMHighTiming).toBeGreaterThan(peakRPMNoTiming)
+    })
+  })
+
+  describe('rotor variants', () => {
+    it('LV42 (kvScale=30/42) has higher stall torque than LV30 at same timing', () => {
+      const lv30 = torquePowerCurve({ ...baseParams, rotorKvScale: 1.0 })
+      const lv42 = torquePowerCurve({ ...baseParams, rotorKvScale: 30 / 42 })
+      expect(lv42[0].torque).toBeGreaterThan(lv30[0].torque)
+    })
+
+    it('LV42 has lower RPM ceiling than LV30 at same timing', () => {
+      const lv30 = torquePowerCurve({ ...baseParams, rotorKvScale: 1.0 })
+      const lv42 = torquePowerCurve({ ...baseParams, rotorKvScale: 30 / 42 })
+      const lastNonZeroLV30 = [...lv30].reverse().find(p => p.torque > 0)!
+      const lastNonZeroLV42 = [...lv42].reverse().find(p => p.torque > 0)!
+      expect(lastNonZeroLV42.rpm).toBeLessThan(lastNonZeroLV30.rpm)
+    })
+
+    it('all rotor variants conserve peak power near 100%', () => {
+      for (const kvScale of [1.0, 30 / 38, 30 / 42]) {
+        const pts = torquePowerCurve({ ...baseParams, rotorKvScale: kvScale })
+        const maxP = Math.max(...pts.map(p => p.power))
+        expect(maxP).toBeCloseTo(100, 1)
+      }
+    })
+
+    it('LV38 stall torque is between LV30 and LV42', () => {
+      const lv30 = torquePowerCurve({ ...baseParams, rotorKvScale: 1.0 })[0].torque
+      const lv38 = torquePowerCurve({ ...baseParams, rotorKvScale: 30 / 38 })[0].torque
+      const lv42 = torquePowerCurve({ ...baseParams, rotorKvScale: 30 / 42 })[0].torque
+      expect(lv38).toBeGreaterThan(lv30)
+      expect(lv42).toBeGreaterThan(lv38)
+    })
+  })
+
+  it('turboActive=true shifts peak power to higher RPM than turboActive=false', () => {
+    const withTurbo = torquePowerCurve({ ...baseParams, turboTiming: 40, turboActive: true })
+    const noTurbo = torquePowerCurve({ ...baseParams, turboTiming: 40, turboActive: false })
+    const peakTurboRPM = withTurbo.reduce((best, p) => (p.power > best.power ? p : best)).rpm
+    const peakNoTurboRPM = noTurbo.reduce((best, p) => (p.power > best.power ? p : best)).rpm
+    expect(peakTurboRPM).toBeGreaterThan(peakNoTurboRPM)
+  })
+
+  it('curve bends through boost zone when boost timing > 0', () => {
+    const withBoost = torquePowerCurve({ ...baseParams, boostTiming: 30, boostStartRPM: 5000, boostEndRPM: 20000 })
+    const noBoost = torquePowerCurve(baseParams)
     const aboveBoostIdx = withBoost.findIndex(p => p.rpm > 20000)
     expect(aboveBoostIdx).toBeGreaterThan(0)
-
-    // The curves should differ in the above-boost region
-    const withBoostAbove = withBoost[aboveBoostIdx].torque
-    const noBoostAbove = noBoost[aboveBoostIdx].torque
-    expect(withBoostAbove).not.toBeCloseTo(noBoostAbove, 0)
-  })
-
-  it('turboActive=true produces a higher peak RPM ceiling than turboActive=false', () => {
-    const withTurbo = torquePowerCurve({ ...baseParams, turboTiming: 40, turboActive: true })
-    const noTurbo = torquePowerCurve({ ...baseParams, turboTiming: 40, turboActive: false })
-
-    // With turbo: effective timing is higher everywhere → RPM_max is higher → torque reaches 0 at higher RPM
-    const lastNonZeroTurbo = [...withTurbo].reverse().find(p => p.torque > 0)!
-    const lastNonZeroNoTurbo = [...noTurbo].reverse().find(p => p.torque > 0)!
-    expect(lastNonZeroTurbo.rpm).toBeGreaterThan(lastNonZeroNoTurbo.rpm)
-  })
-
-  it('turboActive=true produces a broader curve shape than turboActive=false', () => {
-    const withTurbo = torquePowerCurve({ ...baseParams, turboTiming: 40, turboActive: true })
-    const noTurbo = torquePowerCurve({ ...baseParams, turboTiming: 40, turboActive: false })
-    // Turbo extends RPM ceiling; at the same absolute RPM index the turbo curve retains
-    // more torque because it hasn't fallen as far toward its (higher) zero-crossing.
-    const midIdx = Math.floor(withTurbo.length / 2)
-    expect(withTurbo[midIdx].torque).toBeGreaterThan(noTurbo[midIdx].torque)
+    expect(withBoost[aboveBoostIdx].torque).not.toBeCloseTo(noBoost[aboveBoostIdx].torque, 0)
   })
 })
 

--- a/lib/esc/model.ts
+++ b/lib/esc/model.ts
@@ -1,5 +1,12 @@
 import type { ThrottleCurveMode } from './config'
 
+// Converts combined ESC timing degrees to an effective field-weakening angle.
+// Calibrated from real hardware: Acuvance Xarvis XX + Agile 10.5T on 2S (8.4V),
+// 95° combined timing → ~100k RPM peak. Derived: cos⁻¹(32k/100k) / 95° ≈ 0.75.
+const TIMING_ADVANCE_SCALE = 0.75
+
+const VOLTAGE_2S = 8.4
+
 export function motorKV(turnCount: number): number {
   return 40_000 / turnCount
 }
@@ -31,6 +38,13 @@ export function effectiveTiming(
   )
 }
 
+// Effective field-weakening angle in radians, clamped just below 90°
+// to keep cos() positive and torque physically meaningful.
+function fieldAngle(totalTimingDeg: number): number {
+  const raw = totalTimingDeg * TIMING_ADVANCE_SCALE * (Math.PI / 180)
+  return Math.min(raw, (89 * Math.PI) / 180)
+}
+
 export type TorquePowerParams = {
   motorTurn: number
   motorCanTiming: number
@@ -39,16 +53,29 @@ export type TorquePowerParams = {
   boostEndRPM: number
   turboTiming: number
   turboActive: boolean
+  // KV scale relative to LV30 standard rotor (1.0 = LV30, 30/38 = LV38, 30/42 = LV42).
+  // Defaults to 1.0 (LV30) if omitted.
+  rotorKvScale?: number
 }
 
 export type TorquePowerPoint = { rpm: number; torque: number; power: number }
 
 export function torquePowerCurve(params: TorquePowerParams, N = 200): TorquePowerPoint[] {
-  const kv = motorKV(params.motorTurn)
-  const rpmNoloadBase = kv * 8.4
-  const rpmSampleMax = rpmNoloadBase * 1.6
+  const kvBase = motorKV(params.motorTurn)
+  const rotorKvScale = params.rotorKvScale ?? 1.0
+  // No-load RPM for this rotor at 0° timing
+  const rpmBase = kvBase * rotorKvScale * VOLTAGE_2S
+  // LV30 reference values for normalization (kvScale = 1.0, 0° timing)
+  const rpmBaseRef = kvBase * VOLTAGE_2S
+  const T_ref = 1.0            // LV30 stall torque at 0° timing
+  const P_ref = rpmBaseRef / 4 // LV30 peak power (occurs at RPM_max/2 for linear T-RPM)
 
-  const raw: { rpm: number; torque: number; power: number }[] = []
+  // Sample range covers all configured timing including turbo, so the axis is
+  // stable when the turbo toggle is flipped and ghost curves are visible.
+  const thetaForRange = params.motorCanTiming + params.boostTiming + params.turboTiming
+  const rpmSampleMax = (rpmBase / Math.cos(fieldAngle(thetaForRange))) * 1.1
+
+  const raw: TorquePowerPoint[] = []
   for (let i = 0; i <= N; i++) {
     const rpm = (i / N) * rpmSampleMax
     const theta = effectiveTiming(
@@ -60,19 +87,24 @@ export function torquePowerCurve(params: TorquePowerParams, N = 200): TorquePowe
       params.turboTiming,
       params.turboActive,
     )
-    const rpmMax = rpmNoloadBase * (1 + theta * 0.007)
-    const tStall = Math.cos((theta * Math.PI) / 180)
-    const torque = Math.max(0, tStall * (1 - rpm / rpmMax))
-    const power = torque * rpm
-    raw.push({ rpm, torque, power })
+    const beta = fieldAngle(theta)
+    const cosBeta = Math.cos(beta)
+
+    // Field weakening: stall torque ∝ cos(β)/kvScale, RPM ceiling ∝ 1/cos(β)
+    // Their product = rpmBase/kvScale = KV_base × V = constant — timing conserves power.
+    const tStall = (1 / rotorKvScale) * cosBeta
+    const rpmCeil = rpmBase / cosBeta
+
+    const torque = Math.max(0, tStall * (1 - rpm / rpmCeil))
+    raw.push({ rpm, torque, power: torque * rpm })
   }
 
-  const maxTorque = Math.max(...raw.map(p => p.torque))
-  const maxPower = Math.max(...raw.map(p => p.power))
+  // Normalize to LV30-at-0°-timing reference so the chart communicates
+  // absolute losses: stall torque < 100% = timing cost, > 100% = stronger rotor.
   return raw.map(p => ({
     rpm: p.rpm,
-    torque: maxTorque > 0 ? (p.torque / maxTorque) * 100 : 0,
-    power: maxPower > 0 ? (p.power / maxPower) * 100 : 0,
+    torque: (p.torque / T_ref) * 100,
+    power: (p.power / P_ref) * 100,
   }))
 }
 
@@ -128,7 +160,6 @@ export type BrakePoint = { input: number; force: number }
 export function brakeCurve(params: BrakeCurveParams, N = 200): BrakePoint[] {
   const { neutralBrakePower, initialBrakePower, fullBrakePower } = params
 
-  // Phantom points give horizontal tangents at the endpoints (natural boundary).
   const p0 = { y: neutralBrakePower }
   const p1 = { y: neutralBrakePower }
   const p2 = { y: initialBrakePower }
@@ -147,7 +178,6 @@ export function brakeCurve(params: BrakeCurveParams, N = 200): BrakePoint[] {
     points.push({ input, force: Math.min(100, Math.max(0, force)) })
   }
 
-  // Enforce monotonic non-decreasing
   for (let i = 1; i < points.length; i++) {
     if (points[i].force < points[i - 1].force) {
       points[i].force = points[i - 1].force


### PR DESCRIPTION
## Summary

Replaces the approximate RPM scaling constant with a field-weakening model calibrated to real hardware (Acuvance Xarvis XX + Agile 10.5T on 2S LiPo).

- **Field weakening physics:** `T_stall(θ) = cos(β)`, `RPM_max(θ) = RPM_base / cos(β)` — their product is constant, so timing redistributes power rather than creating it
- **Calibrated constant:** `TIMING_ADVANCE_SCALE = 0.75` converts ESC timing degrees to effective field angle, derived from the real data point: 95° combined timing → ~100k RPM peak
- **Dynamic sample range:** `rpmSampleMax` computed from configured max timing + 10% headroom (was a fixed `1.6×` base multiplier)
- **Fixed normalization:** both curves normalize to LV30/0°-timing reference, so stall torque below 100% visually communicates the timing cost
- **Rotor variant support:** `lib/esc/config.ts` adds `RotorVariant` type and `ROTOR_VARIANTS` (LV30/LV38/LV42) with kvScale factors; `rotorKvScale` is optional in `TorquePowerParams` (defaults to LV30)

## Test plan

- [x] 44 Vitest tests pass
- [x] Stall torque at 0° timing / LV30 = 100% (fixed reference)
- [x] 95° combined timing: stall torque ~44% (boost hasn't ramped in at RPM=0; can+turbo only = 85°), RPM ceiling 90k–115k
- [x] Peak power conserved at ~100% across all timing and rotor combinations
- [x] Higher timing shifts peak power RPM rightward without increasing its magnitude
- [x] LV42 > LV38 > LV30 stall torque; LV42 < LV30 RPM ceiling
- [x] `tsc --noEmit` and `npm run lint` pass

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)