### PR TITLE
docs: amend specs with backlog requirements and spec amendment workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,17 @@
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
 
-## Role
+## Roles
+
+### Owner (Logan)
+Holds domain knowledge — RC drift, ESC behavior, real-world car performance — and is the ground truth for whether a solution actually works. Identifies problems, sets product direction, and makes all final decisions. The owner's role is to ensure the AI's capabilities are applied toward the right goals, not to implement software.
+
+### AI Collaborator
+Holds solution knowledge — what approaches exist, their tradeoffs, and how to build them. Responsible for strategy, software implementation, and workflow facilitation. When proposing a direction, the AI presents options and tradeoffs; it does not make product decisions. The owner approves or redirects before anything is built.
+
+**The key dynamic:** the owner brings the problems and the final say; the AI brings the means to solve them. Neither operates well without the other's input.
+
+## Agent role
 You are an AI collaborator on hotdog-racing.com. Before writing any code or making suggestions, read `docs/site-prd.md` for project context. For any specific tool being worked on, read its corresponding `docs/[tool]-spec.md`.
 
 ## Coding Principles

--- a/docs/agents/issue-workflow.md
+++ b/docs/agents/issue-workflow.md
@@ -81,12 +81,13 @@ Once the user approves, commit the changes and open a PR referencing the issue (
 
 When new problems or ideas surface during development — from the user, from testing, or from implementation discoveries — follow this sequence:
 
-1. **Reframe as a problem**, not a solution. "Users can't tell X" rather than "add feature Y." Keep solution space open.
-2. **Identify the right spec.** Does this belong in `docs/site-prd.md`, an existing tool spec (`docs/[tool]-prd.md`), or does it need a new spec? If no spec exists for the area, create one before proceeding.
-3. **Update the spec first.** Add the problem as a requirement in the relevant spec document. This is the source of truth — the spec must reflect the full intended scope before any issue is created.
-4. **Then create issues.** Issues derive from the spec. An issue that isn't anchored to a spec entry will drift and become hard to evaluate or prioritize.
+1. **Reframe as a problem**, not a solution. "Users can't tell X" rather than "add feature Y." The user's original phrasing often contains an implied solution — strip it out and state the underlying problem clearly.
+2. **Discuss the approach.** For each problem, explore how it could be solved before committing to anything. What are the options? What are the tradeoffs? What fits the project's constraints and aesthetic? Do this without anchoring to how the user originally described the idea — their list is a starting point, not a spec. Reach explicit agreement on the approach before writing anything down.
+3. **Identify the right spec.** Does this belong in `docs/site-prd.md`, an existing tool spec (`docs/[tool]-prd.md`), or does it need a new spec? If no spec exists for the area, create one before proceeding.
+4. **Update the spec.** Add the agreed approach as a requirement in the relevant spec document. The spec is the source of truth — it must reflect considered decisions, not just a reformatted to-do list.
+5. **Then create issues.** Issues derive from the spec. An issue that isn't anchored to a spec entry will drift and become hard to evaluate or prioritize.
 
-**Never create issues for new work without first updating the relevant spec.** If you skip this step, the spec and the tracker will diverge and the spec loses its value as a source of truth.
+**Never create issues for new work without first completing steps 1–4.** If you skip the discussion step, you risk building the wrong thing — just faster.
 
 ---
 

--- a/docs/agents/issue-workflow.md
+++ b/docs/agents/issue-workflow.md
@@ -77,6 +77,19 @@ Wait for the user's approval before proceeding.
 
 Once the user approves, commit the changes and open a PR referencing the issue (e.g. `Closes #10`). The PR description should include what was built and any notable decisions. The Vercel preview URL will be available on the PR for final visual verification.
 
+## Amending a spec mid-project
+
+When new problems or ideas surface during development — from the user, from testing, or from implementation discoveries — follow this sequence:
+
+1. **Reframe as a problem**, not a solution. "Users can't tell X" rather than "add feature Y." Keep solution space open.
+2. **Identify the right spec.** Does this belong in `docs/site-prd.md`, an existing tool spec (`docs/[tool]-prd.md`), or does it need a new spec? If no spec exists for the area, create one before proceeding.
+3. **Update the spec first.** Add the problem as a requirement in the relevant spec document. This is the source of truth — the spec must reflect the full intended scope before any issue is created.
+4. **Then create issues.** Issues derive from the spec. An issue that isn't anchored to a spec entry will drift and become hard to evaluate or prioritize.
+
+**Never create issues for new work without first updating the relevant spec.** If you skip this step, the spec and the tracker will diverge and the spec loses its value as a source of truth.
+
+---
+
 ## Creating issues outside of `/to-issues`
 
 When creating a GitHub issue manually (e.g. to track a bug, a model fix, or a UI slice that emerged during implementation), always apply labels immediately after creation — never leave an issue unlabeled.

--- a/docs/esc-tool-prd.md
+++ b/docs/esc-tool-prd.md
@@ -18,6 +18,14 @@ Each tab contains a parameter panel (sliders and selectors) and a D3.js chart. O
 
 All slider values auto-save to localStorage on change and restore on page load.
 
+### Chart interactions (all tabs)
+
+Every D3 chart must support a hover tooltip:
+- On mouse hover (or touch drag on mobile), a tooltip appears anchored to the cursor's x-position
+- Tooltip displays the x-axis value (RPM or throttle %) and all y-axis values at that position (e.g. torque %, power % on the Timing tab)
+- Tooltip follows the cursor and must not clip outside chart bounds
+- A vertical hairline at the cursor x-position helps read values off the curve
+
 ---
 
 ## Tab 1: Timing
@@ -32,16 +40,19 @@ Show how motor can timing, boost timing, and turbo timing interact to shift the 
 - Y-axis left: Torque (normalized, 0–100%)
 - Y-axis right: Power (normalized, 0–100%)
 - Two curves on the same chart: torque (solid) and power (dashed)
+- A persistent 0° timing reference curve (all timing parameters at zero) is always visible as a muted/dashed background line, regardless of current settings — gives users a baseline to compare against
 - Vertical line at `rev_limit_rpm` if enabled
 - When turbo toggle is ON: primary curves show boost + turbo state; a faded ghost of the boost-only curves stays visible behind them
+- Y-axis left (torque) scales dynamically — upper bound expands to fit the maximum torque value produced by current settings; the curve must never be clipped at the top
 
 The curve is not static — it **bends** through the boost RPM zone because effective timing changes with RPM. Below `boost_start_rpm` the curve reflects base timing only. Through the boost ramp zone it transitions. Above `boost_end_rpm` it reflects full boost timing.
 
 ### Live Readout
-A prominent numeric display showing **total timing at peak power RPM**:
-`motor_can_timing + boost_timing (at that RPM) + turbo_timing (if toggled)`
+A prominent numeric display with three metrics, all updating continuously as sliders move:
 
-Updates continuously as sliders move.
+- **Total timing at peak power RPM** — `motor_can_timing + boost_timing (at that RPM) + turbo_timing (if toggled)`
+- **Total cumulative timing** — the area under the `θ_total(rpm)` curve across the full RPM range; represents aggregate timing exposure across the power band
+- **Peak RPM** — the RPM at which the power curve reaches its maximum for the current settings and rotor variant
 
 ### Parameters
 
@@ -198,6 +209,29 @@ components/esc/
 ```
 
 Components own rendering only. All curve data is computed in `lib/esc/model.ts` and passed in as props.
+
+---
+
+## Real-World Validation
+
+The math model is physically motivated but unvalidated against measured data. The goal is to close this gap by testing the actual reference hardware (Acuvance Xarvis XX + Agile 10.5T, 2S) and calibrating the model where it diverges from reality.
+
+### Process
+
+1. **Draft a test plan** — document what to measure (peak RPM at minimum), how to measure it (optical tachometer, ESC telemetry, or video analysis), which settings to vary, and what data to record. This phase can be completed by an agent.
+2. **Run the tests** — owner runs the physical tests on the car and records measurements.
+3. **Calibrate** — compare measurements against model output at matching parameter values; adjust constants in `lib/esc/model.ts` where the model diverges meaningfully from reality.
+
+### What to measure (minimum)
+
+- Peak no-load RPM at various can timing values (0°, 10°, 20°, 30°) with boost and turbo off
+- Peak no-load RPM at several boost timing values with fixed can timing
+
+These data points are sufficient to validate `RPM_max(θ)` — the most consequential output of the model.
+
+### Calibration target
+
+The model should predict peak RPM within ~10% of measured values across the tested parameter range. Constants to tune: the `0.007` timing multiplier in `RPM_max(θ)` and the `RPM_noload_base` calculation.
 
 ---
 

--- a/docs/site-prd.md
+++ b/docs/site-prd.md
@@ -40,7 +40,7 @@ A personal hub for the RC drift community. The site combines static content (abo
 ### Static Content
 | Route | Purpose |
 |---|---|
-| `/` | Home — Hero → Featured Tools → Social (Latest Episode + Instagram profile card) → Sponsors → Latest Blog Posts |
+| `/` | Home — Hero → Featured Tools → Social (Latest Episode + Instagram profile card) → Sponsors → Latest Blog Posts. Tool cards must include a visual element (screenshot, icon, or illustration) — text-only cards are not sufficient. |
 | `/about` | Who Logan is, RC background and resume |
 | `/podcast` | Full episode list pulled from YouTube channel |
 | `/events` | Upcoming and past events — self-managed static config |
@@ -109,7 +109,8 @@ Visualize how gyro gain, gyro direction, and servo speed/endpoint settings affec
 - **Aesthetic:** Clean, technical, dark-mode friendly. Think tuning software, not a lifestyle blog. Pages should adopt a congruent global template.
 - **Color scheme:** Follows system preference (light/dark) by default. Manual toggle in the nav allows override.
 - **Palette:** Primary accent `#FF0020` with tints and shades. No pure black (`#000`) or pure white (`#fff`) — use near-black (e.g. `#0D0D0D`) and near-white (e.g. `#F5F5F5`) instead. Accent used for interactive elements: buttons, links, active nav, slider handles, highlights.
-- **Typography:** Geist Sans for content pages; Geist Mono for tool UIs, readouts, and numeric values. Both are bundled with Next.js via `create-next-app` — no extra dependency.
+- **Logo:** The Hotdog Racing logo is part of the brand identity and must appear in the site header/nav. It should also inform the favicon. Logo file (SVG preferred) to be provided by the owner before implementation.
+- **Typography:** Geist Sans for content pages; Geist Mono for tool UIs, readouts, and numeric values. Both are bundled with Next.js via `create-next-app` — no extra dependency. The "Hotdog" and "Racing" portions of the wordmark each have distinct brand fonts from the official style guide — these must be applied wherever the full wordmark appears (header, hero, OG images). Font files to be provided by the owner.
 - **Mobile-first:** Tools are designed for phone use at the track — touch-friendly controls, finger-sized tap targets, portrait-friendly layouts. Tablet and desktop are enhanced experiences, not the baseline.
 - **PWA:** Custom branded install prompt triggered after a user visits any tool page. Service worker caches all tool assets for full offline use. No login required — localStorage handles all persistence.
 
@@ -147,7 +148,7 @@ Dedicated `/events` page listing upcoming (and past) events. Data managed as a s
 
 ## Sponsors
 
-Dedicated section on the home page — sponsor logos with links to their websites. Also mentioned on the `/about` page. Sponsor data stored as a static JSON or TypeScript config file in the repo (name, logo, URL). Adding/removing a sponsor means updating that file and pushing to main.
+Dedicated section on the home page — sponsor logos with links to their websites. Also mentioned on the `/about` page. Sponsor data stored as a static JSON or TypeScript config file in the repo (name, logo, URL). Adding/removing a sponsor means updating that file and pushing to main. Every sponsor entry must be complete — name, logo file (SVG or optimized PNG), and URL are all required fields. Incomplete entries (missing logo or name) should not render. Sponsor logo files and brand names to be provided by the owner.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **Spec Amendments** section to `issue-workflow.md` — documents the correct mid-project flow: reframe as problem → update spec → create issues. Closes the workflow gap where issues were being created without a corresponding spec entry.
- Updates `site-prd.md` with explicit requirements for logo, brand fonts (wordmark typography), tool card visual elements, and complete sponsor entries.
- Updates `esc-tool-prd.md` with: 0° timing reference curve always visible, dynamic y-axis scaling (no clipping), hover tooltip on all charts, cumulative timing + peak RPM metrics, and a real-world validation section.

These spec updates are the paper trail behind issues #51–60, which were created before the specs were amended (acknowledged in history).

## Test plan
- [x] Docs read correctly and no broken internal references
- [x] No code changes — no build or lint check required

🤖 Generated with [Claude Code](https://claude.com/claude-code)