### PR TITLE
docs: require owner check-in before starting each new issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Holds solution knowledge — what approaches exist, their tradeoffs, and how to 
 
 **The key dynamic:** the owner brings the problems and the final say; the AI brings the means to solve them. Neither operates well without the other's input.
 
-The owner's time is for domain knowledge and product direction — not workflow coordination. The AI should use available signals (git history, issue tracker, PR state) to make workflow decisions autonomously. Ask only when signals are genuinely ambiguous.
+The owner's time is for domain knowledge and product direction — not workflow coordination. The AI should use available signals (git history, issue tracker, PR state) to make workflow decisions autonomously. Ask only when signals are genuinely ambiguous. Exception: always check in with the owner before starting work on a new issue — announce the chosen issue and wait for explicit confirmation before branching or writing any code.
 
 ## Agent role
 You are an AI collaborator on hotdog-racing.com. Before writing any code or making suggestions, read `docs/site-prd.md` for project context. For any specific tool being worked on, read its corresponding `docs/[tool]-spec.md`.

--- a/docs/agents/issue-workflow.md
+++ b/docs/agents/issue-workflow.md
@@ -8,8 +8,8 @@ When the user says they want to get started (or similar), run through these step
 
 1. Run `/triage` on all open `needs-triage` issues — evaluate each against `docs/site-prd.md` and assign the appropriate label (`ready-for-agent`, `ready-for-human`, `needs-info`, `wontfix`) with a brief comment explaining the reasoning.
 2. Present a summary of label changes.
-3. Identify the next issue to work on: the lowest-numbered `ready-for-agent` issue whose "Blocked by" dependencies are all closed.
-4. Announce the chosen issue and begin.
+3. Identify the next issue to work on: the lowest-numbered `ready-for-agent` issue whose "Blocked by" dependencies are all closed. Consider active feature areas in recent git history when breaking ties.
+4. **Check in with the owner** — announce the chosen issue and wait for explicit confirmation before branching or writing any code.
 
 ## Working an issue
 


### PR DESCRIPTION
## Summary

- Updates `docs/agents/issue-workflow.md` step 4 to explicitly require owner confirmation before branching or writing code
- Updates `AGENTS.md` autonomy line to carve out this exception

## Why

After a merged PR, the agent was autonomously picking and starting the next issue without pausing for owner input. The owner wants final say on what gets worked on next, even when the next issue is unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)