### PR TITLE
feat: ESC Timing tab — 0° reference curve

### DIFF
--- a/components/esc/EscTool.tsx
+++ b/components/esc/EscTool.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/lib/esc/config'
 import type { RotorVariant, ThrottleCurveMode } from '@/lib/esc/config'
 import { effectiveTiming, motorKV, torquePowerCurve } from '@/lib/esc/model'
+import { accentToGhost, readSurfaceColor } from '@/lib/esc/colors'
 import BrakeChart from './BrakeChart'
 import ThrottleChart from './ThrottleChart'
 import TimingChart from './TimingChart'
@@ -86,6 +87,7 @@ const BRAKE_DEFAULTS: BrakeState = {
 }
 
 const LS_KEY = 'esc-tool-settings'
+const ACCENT_COLOR = '#FF0020'
 
 export default function EscTool() {
   const [tab, setTab] = useState<Tab>('timing')
@@ -95,6 +97,19 @@ export default function EscTool() {
   const skipFirstWrite = useRef(true)
   const skipFirstThrottleWrite = useRef(true)
   const skipFirstBrakeWrite = useRef(true)
+
+  const [ghostColor, setGhostColor] = useState('')
+  useEffect(() => {
+    function compute() {
+      setGhostColor(accentToGhost(ACCENT_COLOR, readSurfaceColor()))
+    }
+    compute()
+    const observer = new MutationObserver(compute)
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    mq.addEventListener('change', compute)
+    return () => { observer.disconnect(); mq.removeEventListener('change', compute) }
+  }, [])
 
   // Restore from localStorage on mount
   useEffect(() => {
@@ -448,21 +463,37 @@ export default function EscTool() {
                 <div className="absolute right-3 top-3 z-10 flex flex-col gap-1.5">
                   <div className="flex items-center gap-2">
                     <svg width="20" height="2" viewBox="0 0 20 2" aria-hidden>
-                      <line x1="0" y1="1" x2="20" y2="1" stroke="#FF0020" strokeWidth="2" />
+                      <line x1="0" y1="1" x2="20" y2="1" stroke={ACCENT_COLOR} strokeWidth="2" />
                     </svg>
                     <span className="font-mono text-xs" style={{ color: 'var(--muted)' }}>Torque</span>
                   </div>
                   <div className="flex items-center gap-2">
                     <svg width="20" height="2" viewBox="0 0 20 2" aria-hidden>
-                      <line x1="0" y1="1" x2="20" y2="1" stroke="#FF0020" strokeWidth="2" strokeDasharray="6 3" />
+                      <line x1="0" y1="1" x2="20" y2="1" stroke={ACCENT_COLOR} strokeWidth="2" strokeDasharray="6 3" />
                     </svg>
                     <span className="font-mono text-xs" style={{ color: 'var(--muted)' }}>Power</span>
+                  </div>
+                  {timing.turboActive && ghostColor && (
+                    <div className="flex items-center gap-2">
+                      <svg width="20" height="2" viewBox="0 0 20 2" aria-hidden>
+                        <line x1="0" y1="1" x2="20" y2="1" stroke={ghostColor} strokeWidth="1.5" />
+                      </svg>
+                      <span className="font-mono text-xs" style={{ color: 'var(--muted)' }}>No turbo</span>
+                    </div>
+                  )}
+                  <div className="flex items-center gap-2">
+                    <svg width="20" height="2" viewBox="0 0 20 2" aria-hidden>
+                      <line x1="0" y1="1" x2="20" y2="1" stroke="var(--muted)" strokeWidth="1.5" strokeOpacity="0.55" />
+                    </svg>
+                    <span className="font-mono text-xs" style={{ color: 'var(--muted)' }}>0° ref</span>
                   </div>
                 </div>
                 <TimingChart
                   params={chartParams}
                   revLimitEnabled={timing.revLimitEnabled}
                   revLimitRPM={timing.revLimitRPM}
+                  accentColor={ACCENT_COLOR}
+                  ghostColor={ghostColor}
                 />
               </div>
             </div>

--- a/components/esc/TimingChart.tsx
+++ b/components/esc/TimingChart.tsx
@@ -9,9 +9,17 @@ type Props = {
   params: TorquePowerParams
   revLimitEnabled: boolean
   revLimitRPM: number
+  accentColor?: string
+  ghostColor?: string
 }
 
-export default function TimingChart({ params, revLimitEnabled, revLimitRPM }: Props) {
+export default function TimingChart({
+  params,
+  revLimitEnabled,
+  revLimitRPM,
+  accentColor = '#FF0020',
+  ghostColor,
+}: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
 
@@ -29,6 +37,7 @@ export default function TimingChart({ params, revLimitEnabled, revLimitRPM }: Pr
       const innerH = height - margin.top - margin.bottom
 
       const live = torquePowerCurve(params)
+      const ref = torquePowerCurve({ ...params, motorCanTiming: 0, boostTiming: 0, turboTiming: 0, turboActive: false })
       const ghost = params.turboActive ? torquePowerCurve({ ...params, turboActive: false }) : null
       const maxRPM = live[live.length - 1].rpm
 
@@ -105,24 +114,40 @@ export default function TimingChart({ params, revLimitEnabled, revLimitRPM }: Pr
         .x(d => x(d.rpm))
         .y(d => yR(d.power))
 
-      // Ghost curves when turbo is active
-      if (ghost) {
+      // 0° timing reference — gray, solid torque + dashed power
+      g.append('path')
+        .datum(ref)
+        .attr('fill', 'none')
+        .attr('d', torqueLine)
+        .style('stroke', 'var(--muted)')
+        .style('stroke-width', '1.5')
+        .style('stroke-opacity', '0.55')
+
+      g.append('path')
+        .datum(ref)
+        .attr('fill', 'none')
+        .attr('d', powerLine)
+        .style('stroke', 'var(--muted)')
+        .style('stroke-width', '1.5')
+        .style('stroke-opacity', '0.55')
+        .style('stroke-dasharray', '6 3')
+
+      // No-turbo ghost — complement color, solid torque + dashed power
+      if (ghost && ghostColor) {
         g.append('path')
           .datum(ghost)
           .attr('fill', 'none')
           .attr('d', torqueLine)
-          .style('stroke', 'var(--muted)')
+          .style('stroke', ghostColor)
           .style('stroke-width', '1.5')
-          .style('stroke-opacity', '0.3')
 
         g.append('path')
           .datum(ghost)
           .attr('fill', 'none')
           .attr('d', powerLine)
-          .style('stroke', 'var(--muted)')
+          .style('stroke', ghostColor)
           .style('stroke-width', '1.5')
-          .style('stroke-opacity', '0.3')
-          .style('stroke-dasharray', '5 3')
+          .style('stroke-dasharray', '6 3')
       }
 
       // Rev limit vertical line
@@ -132,7 +157,7 @@ export default function TimingChart({ params, revLimitEnabled, revLimitRPM }: Pr
           .attr('x2', x(revLimitRPM))
           .attr('y1', 0)
           .attr('y2', innerH)
-          .style('stroke', '#FF0020')
+          .style('stroke', accentColor)
           .style('stroke-width', '1.5')
           .style('stroke-dasharray', '4 3')
           .style('stroke-opacity', '0.7')
@@ -143,7 +168,7 @@ export default function TimingChart({ params, revLimitEnabled, revLimitRPM }: Pr
         .datum(live)
         .attr('fill', 'none')
         .attr('d', torqueLine)
-        .style('stroke', '#FF0020')
+        .style('stroke', accentColor)
         .style('stroke-width', '2')
 
       // Live power (dashed)
@@ -151,7 +176,7 @@ export default function TimingChart({ params, revLimitEnabled, revLimitRPM }: Pr
         .datum(live)
         .attr('fill', 'none')
         .attr('d', powerLine)
-        .style('stroke', '#FF0020')
+        .style('stroke', accentColor)
         .style('stroke-width', '2')
         .style('stroke-dasharray', '6 3')
     }
@@ -160,7 +185,7 @@ export default function TimingChart({ params, revLimitEnabled, revLimitRPM }: Pr
     const ro = new ResizeObserver(draw)
     ro.observe(container)
     return () => ro.disconnect()
-  }, [params, revLimitEnabled, revLimitRPM])
+  }, [params, revLimitEnabled, revLimitRPM, accentColor, ghostColor])
 
   return (
     <div ref={containerRef} className="w-full h-full">

--- a/lib/esc/colors.ts
+++ b/lib/esc/colors.ts
@@ -1,0 +1,88 @@
+function hexToComponents(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16) / 255,
+    parseInt(hex.slice(3, 5), 16) / 255,
+    parseInt(hex.slice(5, 7), 16) / 255,
+  ]
+}
+
+function toLinear(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+}
+
+function rgbLuminance(r: number, g: number, b: number): number {
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b)
+}
+
+function hexLuminance(hex: string): number {
+  return rgbLuminance(...hexToComponents(hex))
+}
+
+function contrastRatio(l1: number, l2: number): number {
+  const [hi, lo] = l1 > l2 ? [l1, l2] : [l2, l1]
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
+  const max = Math.max(r, g, b), min = Math.min(r, g, b)
+  const l = (max + min) / 2
+  if (max === min) return [0, 0, l]
+  const d = max - min
+  const s = l < 0.5 ? d / (max + min) : d / (2 - max - min)
+  let h = 0
+  if (max === r) h = ((g - b) / d + 6) % 6
+  else if (max === g) h = (b - r) / d + 2
+  else h = (r - g) / d + 4
+  return [h * 60, s, l]
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const x = c * (1 - Math.abs((h / 60) % 2 - 1))
+  const m = l - c / 2
+  let r = 0, g = 0, b = 0
+  if (h < 60)       { r = c; g = x }
+  else if (h < 120) { r = x; g = c }
+  else if (h < 180) {        g = c; b = x }
+  else if (h < 240) {        g = x; b = c }
+  else if (h < 300) { r = x;        b = c }
+  else              { r = c;        b = x }
+  return [r + m, g + m, b + m]
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (v: number) => Math.round(v * 255).toString(16).padStart(2, '0')
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}
+
+// Returns the --surface CSS variable value from the document root, or a fallback.
+export function readSurfaceColor(): string {
+  if (typeof window === 'undefined') return '#ffffff'
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue('--surface').trim() || '#ffffff'
+}
+
+// Derives a complement-hue ghost color (H+180°) with lightness binary-searched
+// to just exceed 3:1 WCAG contrast against the given surface color.
+// Adapts to both light (#ffffff) and dark (#1a1a1a) surfaces automatically.
+export function accentToGhost(accentHex: string, surfaceHex: string): string {
+  const [ar, ag, ab] = hexToComponents(accentHex)
+  const [h, s] = rgbToHsl(ar, ag, ab)
+  const compHue = (h + 180) % 360
+  const compS = Math.min(s, 0.8)
+  const surfaceLum = hexLuminance(surfaceHex)
+  const onDark = surfaceLum < 0.18
+
+  // Binary search for the lightness boundary where contrast just hits 3:1.
+  // Dark surface → find minimum L bright enough. Light surface → find maximum L dark enough.
+  let lo = 0.0, hi = 1.0
+  for (let i = 0; i < 24; i++) {
+    const mid = (lo + hi) / 2
+    const [cr, cg, cb] = hslToRgb(compHue, compS, mid)
+    const ratio = contrastRatio(rgbLuminance(cr, cg, cb), surfaceLum)
+    if (onDark ? ratio < 3.0 : ratio >= 3.0) lo = mid
+    else hi = mid
+  }
+  const [cr, cg, cb] = hslToRgb(compHue, compS, (lo + hi) / 2)
+  return rgbToHex(cr, cg, cb)
+}


### PR DESCRIPTION
## Summary

- Adds a persistent 0° timing reference curve (gray, solid torque + dashed power) so users can see the no-timing baseline at a glance
- Adds a no-turbo ghost curve when turbo is active — complement hue of the accent color (teal for red), computed to meet WCAG 3:1 contrast against the actual `--surface` CSS variable
- Ghost color adapts to light/dark mode via `MutationObserver` on `<html>` class + `prefers-color-scheme` listener
- `lib/esc/colors.ts` — new pure utility with `accentToGhost(accent, surface)` (complement hue, binary-searched lightness for contrast) and `readSurfaceColor()`, ready for when user-customizable accent color lands

## Test plan

- [x] 0° ref visible at all times: gray solid torque, gray dashed power
- [x] No-turbo ghost appears only when turbo is active, in a clearly distinct teal color
- [x] Toggle light/dark mode while turbo is active — ghost color updates without reload
- [x] All three curves readable simultaneously (red live, teal ghost, gray ref)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)