### PR TITLE
feat: ESC tool graphs — hover tooltip with crosshair

### DIFF
--- a/components/esc/BrakeChart.tsx
+++ b/components/esc/BrakeChart.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
 import { brakeCurve } from '@/lib/esc/model'
-import type { BrakeCurveParams } from '@/lib/esc/model'
+import type { BrakeCurveParams, BrakePoint } from '@/lib/esc/model'
 
 type Props = {
   params: BrakeCurveParams
@@ -12,6 +12,9 @@ type Props = {
 export default function BrakeChart({ params }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const updateRef = useRef<((containerX: number) => void) | null>(null)
+  const hideRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     const container = containerRef.current
@@ -90,7 +93,7 @@ export default function BrakeChart({ params }: Props) {
         .text('Braking Force (%)')
 
       // Brake force curve
-      const line = d3.line<{ input: number; force: number }>()
+      const line = d3.line<BrakePoint>()
         .x(d => x(d.input))
         .y(d => y(d.force))
 
@@ -119,6 +122,46 @@ export default function BrakeChart({ params }: Props) {
         .style('fill', '#FF0020')
         .style('stroke', 'var(--surface)')
         .style('stroke-width', '2')
+
+      // Crosshair and hover dot
+      const crosshair = g.append('line')
+        .attr('y1', 0).attr('y2', innerH)
+        .style('stroke', 'var(--foreground)').style('stroke-width', '1')
+        .style('stroke-dasharray', '3 2').style('opacity', '0')
+        .style('pointer-events', 'none')
+
+      const dot = g.append('circle').attr('r', 4)
+        .style('fill', '#FF0020').style('stroke', 'var(--surface)').style('stroke-width', '2')
+        .style('opacity', '0').style('pointer-events', 'none')
+
+      const bisect = d3.bisector((d: BrakePoint) => d.input).left
+
+      updateRef.current = (containerX: number) => {
+        const innerX = containerX - margin.left
+        const inputVal = x.invert(Math.max(0, Math.min(innerW, innerX)))
+        const i = bisect(data, inputVal, 1, data.length - 1)
+        const pt = inputVal - data[i - 1].input <= data[i].input - inputVal ? data[i - 1] : data[i]
+        const dotX = x(pt.input)
+
+        crosshair.attr('x1', dotX).attr('x2', dotX).style('opacity', '0.6')
+        dot.attr('cx', dotX).attr('cy', y(pt.force)).style('opacity', '1')
+
+        const tt = tooltipRef.current
+        if (!tt) return
+        tt.innerHTML = `<div>Input ${pt.input.toFixed(0)}%</div><div>Force ${pt.force.toFixed(1)}%</div>`
+        const tipW = tt.offsetWidth
+        const rawLeft = margin.left + dotX + 12
+        tt.style.left = `${rawLeft + tipW > width ? Math.max(0, margin.left + dotX - tipW - 12) : rawLeft}px`
+        tt.style.top = `${margin.top + 4}px`
+        tt.style.opacity = '1'
+      }
+
+      hideRef.current = () => {
+        crosshair.style('opacity', '0')
+        dot.style('opacity', '0')
+        const tt = tooltipRef.current
+        if (tt) tt.style.opacity = '0'
+      }
     }
 
     draw()
@@ -128,8 +171,31 @@ export default function BrakeChart({ params }: Props) {
   }, [params])
 
   return (
-    <div ref={containerRef} className="w-full h-full">
+    <div ref={containerRef} className="relative w-full h-full">
       <svg ref={svgRef} />
+      <div
+        className="absolute inset-0 touch-none"
+        onPointerDown={(e) => {
+          if (e.pointerType !== 'mouse') e.currentTarget.setPointerCapture(e.pointerId)
+          updateRef.current?.(e.nativeEvent.offsetX)
+        }}
+        onPointerMove={(e) => updateRef.current?.(e.nativeEvent.offsetX)}
+        onPointerUp={(e) => { if (e.pointerType !== 'mouse') hideRef.current?.() }}
+        onPointerLeave={(e) => { if (e.pointerType === 'mouse') hideRef.current?.() }}
+        onPointerCancel={() => hideRef.current?.()}
+      />
+      <div
+        ref={tooltipRef}
+        className="pointer-events-none absolute z-10 rounded text-[10px] font-mono leading-relaxed opacity-0"
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--border)',
+          color: 'var(--foreground)',
+          padding: '4px 8px',
+          whiteSpace: 'nowrap',
+          transition: 'opacity 80ms',
+        }}
+      />
     </div>
   )
 }

--- a/components/esc/ThrottleChart.tsx
+++ b/components/esc/ThrottleChart.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
 import { throttleCurve } from '@/lib/esc/model'
-import type { ThrottleCurveParams } from '@/lib/esc/model'
+import type { ThrottleCurveParams, ThrottlePoint } from '@/lib/esc/model'
 
 type Props = {
   params: ThrottleCurveParams
@@ -12,6 +12,9 @@ type Props = {
 export default function ThrottleChart({ params }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const updateRef = useRef<((containerX: number) => void) | null>(null)
+  const hideRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     const container = containerRef.current
@@ -102,7 +105,7 @@ export default function ThrottleChart({ params }: Props) {
         .text('Motor Power (%)')
 
       // Power curve
-      const line = d3.line<{ stick: number; power: number }>()
+      const line = d3.line<ThrottlePoint>()
         .x(d => x(d.stick))
         .y(d => y(d.power))
 
@@ -112,6 +115,46 @@ export default function ThrottleChart({ params }: Props) {
         .attr('d', line)
         .style('stroke', '#FF0020')
         .style('stroke-width', '2')
+
+      // Crosshair and hover dot
+      const crosshair = g.append('line')
+        .attr('y1', 0).attr('y2', innerH)
+        .style('stroke', 'var(--foreground)').style('stroke-width', '1')
+        .style('stroke-dasharray', '3 2').style('opacity', '0')
+        .style('pointer-events', 'none')
+
+      const dot = g.append('circle').attr('r', 4)
+        .style('fill', '#FF0020').style('stroke', 'var(--surface)').style('stroke-width', '2')
+        .style('opacity', '0').style('pointer-events', 'none')
+
+      const bisect = d3.bisector((d: ThrottlePoint) => d.stick).left
+
+      updateRef.current = (containerX: number) => {
+        const innerX = containerX - margin.left
+        const stickVal = x.invert(Math.max(0, Math.min(innerW, innerX)))
+        const i = bisect(data, stickVal, 1, data.length - 1)
+        const pt = stickVal - data[i - 1].stick <= data[i].stick - stickVal ? data[i - 1] : data[i]
+        const dotX = x(pt.stick)
+
+        crosshair.attr('x1', dotX).attr('x2', dotX).style('opacity', '0.6')
+        dot.attr('cx', dotX).attr('cy', y(pt.power)).style('opacity', '1')
+
+        const tt = tooltipRef.current
+        if (!tt) return
+        tt.innerHTML = `<div>Stick ${pt.stick.toFixed(0)}%</div><div>Power ${pt.power.toFixed(1)}%</div>`
+        const tipW = tt.offsetWidth
+        const rawLeft = margin.left + dotX + 12
+        tt.style.left = `${rawLeft + tipW > width ? Math.max(0, margin.left + dotX - tipW - 12) : rawLeft}px`
+        tt.style.top = `${margin.top + 4}px`
+        tt.style.opacity = '1'
+      }
+
+      hideRef.current = () => {
+        crosshair.style('opacity', '0')
+        dot.style('opacity', '0')
+        const tt = tooltipRef.current
+        if (tt) tt.style.opacity = '0'
+      }
     }
 
     draw()
@@ -121,8 +164,31 @@ export default function ThrottleChart({ params }: Props) {
   }, [params])
 
   return (
-    <div ref={containerRef} className="w-full h-full">
+    <div ref={containerRef} className="relative w-full h-full">
       <svg ref={svgRef} />
+      <div
+        className="absolute inset-0 touch-none"
+        onPointerDown={(e) => {
+          if (e.pointerType !== 'mouse') e.currentTarget.setPointerCapture(e.pointerId)
+          updateRef.current?.(e.nativeEvent.offsetX)
+        }}
+        onPointerMove={(e) => updateRef.current?.(e.nativeEvent.offsetX)}
+        onPointerUp={(e) => { if (e.pointerType !== 'mouse') hideRef.current?.() }}
+        onPointerLeave={(e) => { if (e.pointerType === 'mouse') hideRef.current?.() }}
+        onPointerCancel={() => hideRef.current?.()}
+      />
+      <div
+        ref={tooltipRef}
+        className="pointer-events-none absolute z-10 rounded text-[10px] font-mono leading-relaxed opacity-0"
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--border)',
+          color: 'var(--foreground)',
+          padding: '4px 8px',
+          whiteSpace: 'nowrap',
+          transition: 'opacity 80ms',
+        }}
+      />
     </div>
   )
 }

--- a/components/esc/TimingChart.tsx
+++ b/components/esc/TimingChart.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
 import { torquePowerCurve } from '@/lib/esc/model'
-import type { TorquePowerParams } from '@/lib/esc/model'
+import type { TorquePowerParams, TorquePowerPoint } from '@/lib/esc/model'
 
 type Props = {
   params: TorquePowerParams
@@ -22,6 +22,9 @@ export default function TimingChart({
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const updateRef = useRef<((containerX: number) => void) | null>(null)
+  const hideRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     const container = containerRef.current
@@ -106,11 +109,11 @@ export default function TimingChart({
         .style('font-family', 'var(--font-mono, monospace)')
         .text('Motor RPM')
 
-      const torqueLine = d3.line<{ rpm: number; torque: number; power: number }>()
+      const torqueLine = d3.line<TorquePowerPoint>()
         .x(d => x(d.rpm))
         .y(d => yL(d.torque))
 
-      const powerLine = d3.line<{ rpm: number; torque: number; power: number }>()
+      const powerLine = d3.line<TorquePowerPoint>()
         .x(d => x(d.rpm))
         .y(d => yR(d.power))
 
@@ -179,6 +182,52 @@ export default function TimingChart({
         .style('stroke', accentColor)
         .style('stroke-width', '2')
         .style('stroke-dasharray', '6 3')
+
+      // Crosshair and hover dots
+      const crosshair = g.append('line')
+        .attr('y1', 0).attr('y2', innerH)
+        .style('stroke', 'var(--foreground)').style('stroke-width', '1')
+        .style('stroke-dasharray', '3 2').style('opacity', '0')
+        .style('pointer-events', 'none')
+
+      const torqueDot = g.append('circle').attr('r', 4)
+        .style('fill', accentColor).style('stroke', 'var(--surface)').style('stroke-width', '2')
+        .style('opacity', '0').style('pointer-events', 'none')
+
+      const powerDot = g.append('circle').attr('r', 4)
+        .style('fill', 'var(--surface)').style('stroke', accentColor).style('stroke-width', '2')
+        .style('opacity', '0').style('pointer-events', 'none')
+
+      const bisect = d3.bisector((d: TorquePowerPoint) => d.rpm).left
+
+      updateRef.current = (containerX: number) => {
+        const innerX = containerX - margin.left
+        const rpmVal = x.invert(Math.max(0, Math.min(innerW, innerX)))
+        const i = bisect(live, rpmVal, 1, live.length - 1)
+        const pt = rpmVal - live[i - 1].rpm <= live[i].rpm - rpmVal ? live[i - 1] : live[i]
+        const dotX = x(pt.rpm)
+
+        crosshair.attr('x1', dotX).attr('x2', dotX).style('opacity', '0.6')
+        torqueDot.attr('cx', dotX).attr('cy', yL(pt.torque)).style('opacity', '1')
+        powerDot.attr('cx', dotX).attr('cy', yR(pt.power)).style('opacity', '1')
+
+        const tt = tooltipRef.current
+        if (!tt) return
+        tt.innerHTML = `<div>${(pt.rpm / 1000).toFixed(1)}k RPM</div><div>Torque ${pt.torque.toFixed(1)}%</div><div>Power ${pt.power.toFixed(1)}%</div>`
+        const tipW = tt.offsetWidth
+        const rawLeft = margin.left + dotX + 12
+        tt.style.left = `${rawLeft + tipW > width ? Math.max(0, margin.left + dotX - tipW - 12) : rawLeft}px`
+        tt.style.top = `${margin.top + 4}px`
+        tt.style.opacity = '1'
+      }
+
+      hideRef.current = () => {
+        crosshair.style('opacity', '0')
+        torqueDot.style('opacity', '0')
+        powerDot.style('opacity', '0')
+        const tt = tooltipRef.current
+        if (tt) tt.style.opacity = '0'
+      }
     }
 
     draw()
@@ -188,8 +237,31 @@ export default function TimingChart({
   }, [params, revLimitEnabled, revLimitRPM, accentColor, ghostColor])
 
   return (
-    <div ref={containerRef} className="w-full h-full">
+    <div ref={containerRef} className="relative w-full h-full">
       <svg ref={svgRef} />
+      <div
+        className="absolute inset-0 touch-none"
+        onPointerDown={(e) => {
+          if (e.pointerType !== 'mouse') e.currentTarget.setPointerCapture(e.pointerId)
+          updateRef.current?.(e.nativeEvent.offsetX)
+        }}
+        onPointerMove={(e) => updateRef.current?.(e.nativeEvent.offsetX)}
+        onPointerUp={(e) => { if (e.pointerType !== 'mouse') hideRef.current?.() }}
+        onPointerLeave={(e) => { if (e.pointerType === 'mouse') hideRef.current?.() }}
+        onPointerCancel={() => hideRef.current?.()}
+      />
+      <div
+        ref={tooltipRef}
+        className="pointer-events-none absolute z-10 rounded text-[10px] font-mono leading-relaxed opacity-0"
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--border)',
+          color: 'var(--foreground)',
+          padding: '4px 8px',
+          whiteSpace: 'nowrap',
+          transition: 'opacity 80ms',
+        }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds hover tooltips to all three ESC tool graphs (Timing, Throttle, Braking)
- Tooltip shows precise values at the cursor's x-position with a vertical crosshair and accent dot tracking the curve
- Touch support via HTML overlay div with `touch-action: none` and pointer capture — tooltip persists through vertical drag without dismissing

## Test plan
- [x] Timing tab: hover shows `{n}k RPM`, `Torque {n}%`, `Power {n}%`
- [x] Throttle tab: hover shows `Stick {n}%`, `Power {n}%`
- [x] Braking tab: hover shows `Input {n}%`, `Force {n}%`
- [x] Tooltip flips left when near right edge of chart
- [x] Mobile: tap/drag shows and updates tooltip; lifting finger hides it

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)