### PR TITLE
feat: ESC Timing tab — dynamic y-axis upper bound (#58)

### DIFF
--- a/components/esc/TimingChart.tsx
+++ b/components/esc/TimingChart.tsx
@@ -44,9 +44,20 @@ export default function TimingChart({
       const ghost = params.turboActive ? torquePowerCurve({ ...params, turboActive: false }) : null
       const maxRPM = live[live.length - 1].rpm
 
+      // Shared upper bound keeps gridlines aligned with both axes' tick labels.
+      const visible = ghost ? [live, ref, ghost] : [live, ref]
+      let peak = 0
+      for (const curve of visible) {
+        for (const p of curve) {
+          if (p.torque > peak) peak = p.torque
+          if (p.power > peak) peak = p.power
+        }
+      }
+      const yMax = Math.max(100, Math.ceil(peak / 25) * 25)
+
       const x = d3.scaleLinear().domain([0, maxRPM]).range([0, innerW])
-      const yL = d3.scaleLinear().domain([0, 100]).range([innerH, 0])
-      const yR = d3.scaleLinear().domain([0, 100]).range([innerH, 0])
+      const yL = d3.scaleLinear().domain([0, yMax]).range([innerH, 0])
+      const yR = d3.scaleLinear().domain([0, yMax]).range([innerH, 0])
 
       const svg = d3.select(svgEl)
       svg.attr('width', width).attr('height', height).selectAll('*').remove()


### PR DESCRIPTION
## Summary
- Y-axis upper bound now computed from peak torque/power across live, reference, and ghost curves (rounded up to nearest 25, floored at 100).
- Shared upper bound between left (torque) and right (power) axes keeps gridlines aligned with both tick scales.

Closes #58

## Test plan
- [x] Default settings (0° timing, no turbo): y-axis tops out at 100%
- [x] High Motor Can Timing (~30°+): curve fully visible, y-labels expand on multiples of 25
- [x] Turbo on with high turbo timing: turbo curve and no-turbo ghost both fully visible
- [x] Stronger rotor (LV38/LV42) at 0° timing: y-axis stays at 100% (floor works)
- [x] Hover tooltip tracks correctly at expanded scale
- [x] Rev limit line still spans full chart height

🤖 Generated with [Claude Code](https://claude.com/claude-code)