### PR TITLE
feat: ESC Timing tab — cumulative timing and peak RPM metrics (#59)

### DIFF
--- a/components/esc/EscTool.tsx
+++ b/components/esc/EscTool.tsx
@@ -22,7 +22,7 @@ import {
   TURBO_TIMING,
 } from '@/lib/esc/config'
 import type { RotorVariant, ThrottleCurveMode } from '@/lib/esc/config'
-import { effectiveTiming, motorKV, torquePowerCurve } from '@/lib/esc/model'
+import { cumulativeTiming, effectiveTiming, motorKV, peakRPM, torquePowerCurve } from '@/lib/esc/model'
 import { accentToGhost, readSurfaceColor } from '@/lib/esc/colors'
 import BrakeChart from './BrakeChart'
 import ThrottleChart from './ThrottleChart'
@@ -280,7 +280,12 @@ export default function EscTool() {
       timing.turboTiming,
       timing.turboActive,
     )
-    return { rpm: Math.round(peakPower.rpm), deg: Math.round(deg * 10) / 10 }
+    return {
+      rpm: Math.round(peakPower.rpm),
+      deg: Math.round(deg * 10) / 10,
+      cumulativeDeg: cumulativeTiming(chartParams),
+      peakRPM: Math.round(peakRPM(chartParams)),
+    }
   }, [chartParams, timing.motorCanTiming, timing.boostTiming, timing.boostStartRPM, timing.boostEndRPM, timing.turboTiming, timing.turboActive])
 
   const throttleChartParams = useMemo(() => ({
@@ -440,18 +445,36 @@ export default function EscTool() {
             <div className="flex flex-1 flex-col gap-4">
               {/* Live readout */}
               <div
-                className="rounded-lg border px-5 py-4"
+                className="grid grid-cols-1 overflow-hidden rounded-lg border sm:grid-cols-3"
                 style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
               >
-                <p className="mb-0.5 font-mono text-xs uppercase tracking-widest" style={{ color: 'var(--muted)' }}>
-                  Total timing at peak power
-                </p>
-                <p className="font-mono text-3xl font-bold" style={{ color: 'var(--foreground)' }}>
-                  {liveReadout.deg}°
-                  <span className="ml-3 font-mono text-sm font-normal" style={{ color: 'var(--muted)' }}>
-                    @ {(liveReadout.rpm / 1000).toFixed(1)}k RPM
-                  </span>
-                </p>
+                <div className="border-b px-5 py-4 sm:border-b-0 sm:border-r" style={{ borderColor: 'var(--border)' }}>
+                  <p className="mb-0.5 font-mono text-xs uppercase tracking-widest" style={{ color: 'var(--muted)' }}>
+                    Timing @ peak power
+                  </p>
+                  <p className="font-mono text-2xl font-bold" style={{ color: 'var(--foreground)' }}>
+                    {liveReadout.deg}°
+                    <span className="ml-2 font-mono text-xs font-normal" style={{ color: 'var(--muted)' }}>
+                      @ {(liveReadout.rpm / 1000).toFixed(1)}k
+                    </span>
+                  </p>
+                </div>
+                <div className="border-b px-5 py-4 sm:border-b-0 sm:border-r" style={{ borderColor: 'var(--border)' }}>
+                  <p className="mb-0.5 font-mono text-xs uppercase tracking-widest" style={{ color: 'var(--muted)' }}>
+                    Cumulative timing
+                  </p>
+                  <p className="font-mono text-2xl font-bold" style={{ color: 'var(--foreground)' }}>
+                    {liveReadout.cumulativeDeg}°
+                  </p>
+                </div>
+                <div className="px-5 py-4">
+                  <p className="mb-0.5 font-mono text-xs uppercase tracking-widest" style={{ color: 'var(--muted)' }}>
+                    Peak RPM
+                  </p>
+                  <p className="font-mono text-2xl font-bold" style={{ color: 'var(--foreground)' }}>
+                    {(liveReadout.peakRPM / 1000).toFixed(1)}k
+                  </p>
+                </div>
               </div>
 
               {/* Chart */}

--- a/lib/esc/model.test.ts
+++ b/lib/esc/model.test.ts
@@ -4,6 +4,8 @@ import {
   boostTimingAtRPM,
   effectiveTiming,
   torquePowerCurve,
+  cumulativeTiming,
+  peakRPM,
   throttleCurve,
   brakeCurve,
 } from './model'
@@ -205,6 +207,90 @@ describe('torquePowerCurve', () => {
     const aboveBoostIdx = withBoost.findIndex(p => p.rpm > 20000)
     expect(aboveBoostIdx).toBeGreaterThan(0)
     expect(withBoost[aboveBoostIdx].torque).not.toBeCloseTo(noBoost[aboveBoostIdx].torque, 0)
+  })
+})
+
+describe('cumulativeTiming', () => {
+  const baseParams = {
+    motorTurn: 10.5,
+    motorCanTiming: 0,
+    boostTiming: 0,
+    boostStartRPM: 5000,
+    boostEndRPM: 20000,
+    turboTiming: 0,
+    turboActive: false,
+    rotorKvScale: 1.0,
+  }
+
+  it('returns 0 when all timing sources are 0', () => {
+    expect(cumulativeTiming(baseParams)).toBe(0)
+  })
+
+  it('sums can + boost when turbo is inactive', () => {
+    expect(cumulativeTiming({ ...baseParams, motorCanTiming: 30, boostTiming: 10, turboTiming: 55 })).toBe(40)
+  })
+
+  it('includes turbo timing when turboActive is true', () => {
+    expect(cumulativeTiming({ ...baseParams, motorCanTiming: 30, boostTiming: 10, turboTiming: 55, turboActive: true })).toBe(95)
+  })
+
+  it('is independent of rotor variant and motor turn', () => {
+    const a = cumulativeTiming({ ...baseParams, motorTurn: 4.5, rotorKvScale: 30 / 42, motorCanTiming: 12, boostTiming: 8 })
+    const b = cumulativeTiming({ ...baseParams, motorTurn: 21.5, rotorKvScale: 1.0, motorCanTiming: 12, boostTiming: 8 })
+    expect(a).toBe(b)
+    expect(a).toBe(20)
+  })
+})
+
+describe('peakRPM', () => {
+  const baseParams = {
+    motorTurn: 10.5,
+    motorCanTiming: 0,
+    boostTiming: 0,
+    boostStartRPM: 5000,
+    boostEndRPM: 20000,
+    turboTiming: 0,
+    turboActive: false,
+    rotorKvScale: 1.0,
+  }
+
+  it('equals KV × voltage at zero timing on LV30', () => {
+    // motorKV(10.5) ≈ 3809.52, × 8.4V ≈ 32_000 RPM
+    expect(peakRPM(baseParams)).toBeCloseTo(3809.52 * 8.4, 0)
+  })
+
+  it('matches calibrated 95° real-hardware peak (~100k RPM)', () => {
+    const rpm = peakRPM({ ...baseParams, motorCanTiming: 30, boostTiming: 10, turboTiming: 55, turboActive: true })
+    expect(rpm).toBeGreaterThan(95_000)
+    expect(rpm).toBeLessThan(105_000)
+  })
+
+  it('rises monotonically with cumulative timing', () => {
+    const t0 = peakRPM(baseParams)
+    const t1 = peakRPM({ ...baseParams, motorCanTiming: 15 })
+    const t2 = peakRPM({ ...baseParams, motorCanTiming: 30 })
+    expect(t1).toBeGreaterThan(t0)
+    expect(t2).toBeGreaterThan(t1)
+  })
+
+  it('LV42 has lower peak RPM than LV30 at same timing', () => {
+    const lv30 = peakRPM({ ...baseParams, motorCanTiming: 20, rotorKvScale: 1.0 })
+    const lv42 = peakRPM({ ...baseParams, motorCanTiming: 20, rotorKvScale: 30 / 42 })
+    expect(lv42).toBeLessThan(lv30)
+  })
+
+  it('matches the highest non-zero RPM in the torque curve within sampling tolerance', () => {
+    const params = { ...baseParams, motorCanTiming: 30, boostTiming: 10, turboTiming: 55, turboActive: true }
+    const curve = torquePowerCurve(params, 1000)
+    const lastNonZero = [...curve].reverse().find(p => p.torque > 0)!
+    const sampleStep = curve[1].rpm - curve[0].rpm
+    expect(Math.abs(peakRPM(params) - lastNonZero.rpm)).toBeLessThan(sampleStep * 2)
+  })
+
+  it('ignores turbo timing when turboActive is false', () => {
+    const off = peakRPM({ ...baseParams, motorCanTiming: 10, turboTiming: 55, turboActive: false })
+    const on = peakRPM({ ...baseParams, motorCanTiming: 10, turboTiming: 55, turboActive: true })
+    expect(on).toBeGreaterThan(off)
   })
 })
 

--- a/lib/esc/model.ts
+++ b/lib/esc/model.ts
@@ -60,6 +60,15 @@ export type TorquePowerParams = {
 
 export type TorquePowerPoint = { rpm: number; torque: number; power: number }
 
+export function cumulativeTiming(params: TorquePowerParams): number {
+  return params.motorCanTiming + params.boostTiming + (params.turboActive ? params.turboTiming : 0)
+}
+
+export function peakRPM(params: TorquePowerParams): number {
+  const rpmBase = motorKV(params.motorTurn) * (params.rotorKvScale ?? 1.0) * VOLTAGE_2S
+  return rpmBase / Math.cos(fieldAngle(cumulativeTiming(params)))
+}
+
 export function torquePowerCurve(params: TorquePowerParams, N = 200): TorquePowerPoint[] {
   const kvBase = motorKV(params.motorTurn)
   const rotorKvScale = params.rotorKvScale ?? 1.0


### PR DESCRIPTION
## Summary
- Adds two derived metrics to the Timing tab readout panel: **Cumulative timing** (`canTiming + boostTiming + (turboActive ? turboTiming : 0)`) and **Peak RPM** (physical no-load ceiling at full timing).
- Both implemented as pure functions in `lib/esc/model.ts` with vitest coverage.
- Readout block becomes a 3-column grid (stacks vertically on mobile) so all three metrics — timing@peak-power · cumulative · peak RPM — sit side by side.

Closes #59

## Test plan
- [x] At 0° everywhere: cumulative = 0°, peak RPM ≈ 32k (10.5T motor on 2S)
- [x] Adjusting Can Timing or Boost Timing updates both metrics reactively
- [x] Toggling WOT/Turbo on with turbo timing > 0: cumulative includes turbo, peak RPM rises; toggling off reverses both
- [x] Switching rotor LV30 → LV38 → LV42: peak RPM drops with each step; cumulative timing unchanged
- [x] At ~95° cumulative timing (30 can + 10 boost + 55 turbo, turbo on): peak RPM ≈ 100k (matches calibration)
- [x] Peak RPM matches where the live torque curve hits zero on the chart
- [x] Layout reasonable on mobile (stacked) and desktop (3 columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)