### PR TITLE
feat: hero — perspective grid, touge road, and tool blueprints (#54)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -80,3 +80,18 @@ body {
 
 :root.dark .theme-icon-sun { display: block; }
 :root.dark .theme-icon-moon { display: none; }
+
+@keyframes hero-grid-scroll {
+  from { background-position: 0 0; }
+  to { background-position: 0 60px; }
+}
+
+@keyframes hero-road-scroll {
+  from { transform: translateY(0); }
+  to { transform: translateY(600px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-grid-floor,
+  .hero-road { animation: none !important; }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,28 +23,95 @@ export default async function Home() {
 function HeroSection() {
   return (
     <section className="relative flex min-h-[90vh] flex-col items-center justify-center overflow-hidden bg-near-black text-center">
-      <div className="pointer-events-none absolute inset-0">
-        <svg className="h-full w-full" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <defs>
-            <pattern id="hero-grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-              <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,0,32,0.1)" strokeWidth="0.5" />
-              <animateTransform
-                attributeName="patternTransform"
-                type="translate"
-                from="0 0"
-                to="40 40"
-                dur="8s"
-                repeatCount="indefinite"
+      <div
+        className="pointer-events-none absolute inset-x-0 bottom-0 top-1/2 overflow-hidden"
+        style={{ perspective: '800px' }}
+      >
+        <div
+          className="hero-grid-floor absolute left-1/2 top-0 h-[200%] w-[300%] origin-top"
+          style={{
+            transform: 'translateX(-50%) rotateX(60deg)',
+            backgroundImage:
+              'linear-gradient(to right, rgba(255, 0, 32, 0.4) 1px, transparent 1px), linear-gradient(to bottom, rgba(255, 0, 32, 0.4) 1px, transparent 1px)',
+            backgroundSize: '60px 60px',
+            animation: 'hero-grid-scroll 1.6s linear infinite',
+            maskImage:
+              'linear-gradient(to bottom, transparent 0%, black 25%, black 100%)',
+            WebkitMaskImage:
+              'linear-gradient(to bottom, transparent 0%, black 25%, black 100%)',
+          }}
+        >
+          <div
+            className="hero-road absolute"
+            style={{
+              left: 'calc(50% - 150px)',
+              top: '-600px',
+              width: '300px',
+              height: '1800px',
+              animation: 'hero-road-scroll 16s linear infinite',
+            }}
+          >
+            <svg
+              width="100%"
+              height="100%"
+              viewBox="0 0 300 1800"
+              aria-hidden="true"
+              style={{ filter: 'drop-shadow(0 0 4px rgba(255, 0, 32, 0.6))' }}
+            >
+              <defs>
+                <path
+                  id="hero-touge"
+                  d="M 150 600 C 150 510, 220 520, 220 480 C 220 440, 70 440, 70 400 C 70 360, 220 360, 220 320 C 220 280, 70 280, 70 240 C 70 200, 180 190, 180 150 C 180 110, 150 80, 150 0 M 150 1200 C 150 1110, 220 1120, 220 1080 C 220 1040, 70 1040, 70 1000 C 70 960, 220 960, 220 920 C 220 880, 70 880, 70 840 C 70 800, 180 790, 180 750 C 180 710, 150 680, 150 600 M 150 1800 C 150 1710, 220 1720, 220 1680 C 220 1640, 70 1640, 70 1600 C 70 1560, 220 1560, 220 1520 C 220 1480, 70 1480, 70 1440 C 70 1400, 180 1390, 180 1350 C 180 1310, 150 1280, 150 1200"
+                  fill="none"
+                />
+              </defs>
+              <use
+                href="#hero-touge"
+                x="-45"
+                stroke="rgba(255, 0, 32, 0.8)"
+                strokeWidth="3"
+                strokeLinecap="round"
               />
-            </pattern>
-          </defs>
-          <rect width="100%" height="100%" fill="url(#hero-grid)" />
-        </svg>
+              <use
+                href="#hero-touge"
+                x="45"
+                stroke="rgba(255, 0, 32, 0.8)"
+                strokeWidth="3"
+                strokeLinecap="round"
+              />
+            </svg>
+          </div>
+        </div>
       </div>
+      <div
+        className="pointer-events-none absolute inset-x-0 top-1/2 h-px"
+        style={{
+          background:
+            'linear-gradient(to right, transparent 10%, rgba(255, 0, 32, 0.6) 50%, transparent 90%)',
+          boxShadow: '0 0 40px 4px rgba(255, 0, 32, 0.25)',
+        }}
+      />
       <div
         className="pointer-events-none absolute inset-0"
         style={{ background: 'radial-gradient(ellipse 80% 60% at 50% 50%, transparent 40%, #0D0D0D 100%)' }}
       />
+      <div
+        className="pointer-events-none absolute inset-x-0 top-[5%] z-10 grid grid-cols-1 px-6 md:grid-cols-3"
+        style={{
+          maskImage: 'linear-gradient(to bottom, black 55%, transparent 100%)',
+          WebkitMaskImage: 'linear-gradient(to bottom, black 55%, transparent 100%)',
+        }}
+      >
+        <div className="hidden items-center justify-center md:flex">
+          <EscBlueprint />
+        </div>
+        <div className="flex items-center justify-center">
+          <SuspensionBlueprint />
+        </div>
+        <div className="hidden items-center justify-center md:flex">
+          <GyroBlueprint />
+        </div>
+      </div>
       <div className="relative z-10 px-6">
         <p className="mb-4 font-mono text-xs tracking-[0.3em] text-accent-500 uppercase">RC Drift</p>
         <h1 className="mb-4 text-5xl font-bold tracking-tight text-near-white sm:text-7xl">Hotdog Racing</h1>
@@ -57,6 +124,109 @@ function HeroSection() {
         </Link>
       </div>
     </section>
+  )
+}
+
+const BLUEPRINT_PRIMARY = 'rgba(255, 0, 32, 0.85)'
+const BLUEPRINT_SECONDARY = 'rgba(255, 0, 32, 0.55)'
+const BLUEPRINT_DASH = 'rgba(255, 0, 32, 0.25)'
+const BLUEPRINT_LABEL = 'rgba(255, 0, 32, 0.45)'
+const BLUEPRINT_FONT = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace'
+
+function SuspensionBlueprint() {
+  return (
+    <svg viewBox="0 0 280 200" className="h-auto w-[85%]" aria-hidden="true">
+      <g>
+        <text x="8" y="12" fontSize="6.5" fontFamily={BLUEPRINT_FONT} fill={BLUEPRINT_LABEL} letterSpacing="2">
+          TOP
+        </text>
+        <line x1="20" y1="50" x2="260" y2="50" stroke={BLUEPRINT_DASH} strokeDasharray="3 3" />
+        <line x1="140" y1="18" x2="140" y2="82" stroke="rgba(255, 0, 32, 0.18)" strokeDasharray="2 2" />
+        <rect x="80" y="30" width="120" height="40" rx="3" stroke={BLUEPRINT_SECONDARY} fill="none" />
+        <rect x="40" y="20" width="32" height="12" stroke={BLUEPRINT_PRIMARY} strokeWidth="1.5" fill="none" />
+        <rect x="40" y="68" width="32" height="12" stroke={BLUEPRINT_PRIMARY} strokeWidth="1.5" fill="none" />
+        <g transform="rotate(-4 224 26)">
+          <rect x="208" y="20" width="32" height="12" stroke={BLUEPRINT_PRIMARY} strokeWidth="1.5" fill="none" />
+        </g>
+        <g transform="rotate(4 224 74)">
+          <rect x="208" y="68" width="32" height="12" stroke={BLUEPRINT_PRIMARY} strokeWidth="1.5" fill="none" />
+        </g>
+        <line x1="224" y1="32" x2="224" y2="68" stroke={BLUEPRINT_DASH} />
+      </g>
+      <g transform="translate(0, 110)">
+        <text x="8" y="12" fontSize="6.5" fontFamily={BLUEPRINT_FONT} fill={BLUEPRINT_LABEL} letterSpacing="2">
+          FRONT
+        </text>
+        <line x1="20" y1="78" x2="260" y2="78" stroke={BLUEPRINT_SECONDARY} />
+        <line x1="60" y1="28" x2="60" y2="78" stroke="rgba(255, 0, 32, 0.18)" strokeDasharray="2 2" />
+        <line x1="220" y1="28" x2="220" y2="78" stroke="rgba(255, 0, 32, 0.18)" strokeDasharray="2 2" />
+        <line x1="65" y1="28" x2="55" y2="76" stroke={BLUEPRINT_PRIMARY} strokeWidth="2" />
+        <ellipse cx="55" cy="76" rx="7" ry="2" stroke={BLUEPRINT_SECONDARY} fill="none" />
+        <line x1="215" y1="28" x2="225" y2="76" stroke={BLUEPRINT_PRIMARY} strokeWidth="2" />
+        <ellipse cx="225" cy="76" rx="7" ry="2" stroke={BLUEPRINT_SECONDARY} fill="none" />
+        <rect x="115" y="36" width="50" height="30" stroke={BLUEPRINT_SECONDARY} fill="none" />
+        <line x1="115" y1="40" x2="65" y2="32" stroke={BLUEPRINT_SECONDARY} />
+        <line x1="165" y1="40" x2="215" y2="32" stroke={BLUEPRINT_SECONDARY} />
+        <line x1="115" y1="62" x2="55" y2="72" stroke={BLUEPRINT_SECONDARY} />
+        <line x1="165" y1="62" x2="225" y2="72" stroke={BLUEPRINT_SECONDARY} />
+        <circle cx="115" cy="40" r="1.5" fill={BLUEPRINT_PRIMARY} />
+        <circle cx="165" cy="40" r="1.5" fill={BLUEPRINT_PRIMARY} />
+        <circle cx="115" cy="62" r="1.5" fill={BLUEPRINT_PRIMARY} />
+        <circle cx="165" cy="62" r="1.5" fill={BLUEPRINT_PRIMARY} />
+      </g>
+    </svg>
+  )
+}
+
+function EscBlueprint() {
+  return (
+    <svg viewBox="0 0 160 110" className="h-auto w-[85%]" aria-hidden="true">
+      <text x="8" y="12" fontSize="6.5" fontFamily={BLUEPRINT_FONT} fill={BLUEPRINT_LABEL} letterSpacing="2">
+        ESC
+      </text>
+      <line x1="18" y1="86" x2="148" y2="86" stroke={BLUEPRINT_SECONDARY} />
+      <line x1="18" y1="20" x2="18" y2="86" stroke={BLUEPRINT_SECONDARY} />
+      <line x1="18" y1="86" x2="18" y2="89" stroke={BLUEPRINT_SECONDARY} />
+      <line x1="83" y1="86" x2="83" y2="89" stroke={BLUEPRINT_DASH} />
+      <line x1="148" y1="86" x2="148" y2="89" stroke={BLUEPRINT_SECONDARY} />
+      <line x1="18" y1="86" x2="148" y2="22" stroke={BLUEPRINT_DASH} strokeDasharray="2 2" />
+      <path
+        d="M 18 86 C 35 82, 50 76, 65 65 C 75 55, 80 38, 95 30 C 110 26, 125 22, 148 18"
+        stroke={BLUEPRINT_PRIMARY}
+        strokeWidth="1.8"
+        fill="none"
+      />
+      <circle cx="83" cy="42" r="1.8" fill={BLUEPRINT_PRIMARY} />
+      <text x="88" y="40" fontSize="5" fontFamily={BLUEPRINT_FONT} fill={BLUEPRINT_LABEL} letterSpacing="0.5">
+        BOOST
+      </text>
+      <text x="22" y="100" fontSize="5" fontFamily={BLUEPRINT_FONT} fill={BLUEPRINT_LABEL} letterSpacing="1">
+        THROTTLE
+      </text>
+    </svg>
+  )
+}
+
+function GyroBlueprint() {
+  return (
+    <svg viewBox="0 0 160 110" className="h-auto w-[85%]" aria-hidden="true">
+      <text x="8" y="12" fontSize="6.5" fontFamily={BLUEPRINT_FONT} fill={BLUEPRINT_LABEL} letterSpacing="2">
+        GYRO
+      </text>
+      <path d="M 30 86 A 50 50 0 0 1 130 86" stroke={BLUEPRINT_DASH} strokeDasharray="2 3" fill="none" />
+      <line x1="30" y1="86" x2="30" y2="92" stroke={BLUEPRINT_SECONDARY} />
+      <line x1="130" y1="86" x2="130" y2="92" stroke={BLUEPRINT_SECONDARY} />
+      <line x1="80" y1="86" x2="80" y2="38" stroke={BLUEPRINT_DASH} strokeDasharray="2 2" />
+      <line x1="80" y1="86" x2="115" y2="51" stroke={BLUEPRINT_PRIMARY} strokeWidth="2" />
+      <g transform="rotate(-45 115 51)">
+        <rect x="108" y="41" width="14" height="20" stroke={BLUEPRINT_PRIMARY} strokeWidth="1.4" fill="none" />
+      </g>
+      <path d="M 80 70 A 16 16 0 0 1 91 78" stroke={BLUEPRINT_SECONDARY} fill="none" />
+      <circle cx="80" cy="86" r="2.5" fill={BLUEPRINT_PRIMARY} />
+      <text x="22" y="100" fontSize="5" fontFamily={BLUEPRINT_FONT} fill={BLUEPRINT_LABEL} letterSpacing="1">
+        STEER ANGLE
+      </text>
+    </svg>
   )
 }
 


### PR DESCRIPTION
## Summary
- Replaces the flat black hero with a layered visual aligned with the touge/track motif:
  - Perspective grid floor (`rotateX(60deg)`) scrolling toward a horizon glow line
  - Animated red touge road outline — single SVG path mirrored at ±45px for the two road edges; cubic bookends meet at the seam with vertical tangents so the loop reads as continuous (no visible straight section)
  - Three CAD-style blueprint sketches floating in the upper half representing the planned tools: ESC power curve (with `BOOST` marker), suspension front + top wireframe (with negative camber and front toe), and gyro steering arc with active angle
- Each blueprint occupies one third of the row at `md:` and up; on mobile only the suspension blueprint is visible, centered, at 85% of the viewport
- Mask gradient fades the blueprint band toward the horizon so it doesn't compete with the hero text on wide viewports
- All animations honor `prefers-reduced-motion`

Closes #54.

## Test plan
- [x] Hero renders on the Vercel preview with grid scrolling, road animating, and three blueprints visible on desktop
- [x] On mobile (≤md) only the suspension blueprint shows, centered
- [x] The road loop has no visible straight section at the seam
- [x] Hero text remains readable above the blueprints — bottom of the blueprint band fades into the horizon
- [x] `prefers-reduced-motion` halts both grid and road animation
- [x] `tsc --noEmit` and `npm run lint` pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)