### PR TITLE
chore: ignore .claude/ local config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# claude code local config
+.claude/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore` so per-machine Claude Code config doesn't enter the repo.

## Test plan
- [x] `git status` no longer lists `.claude/` as untracked