### PR TITLE
feat: brand fonts — Calistoga + Yellowtail wordmark

### DIFF
--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Wordmark from '@/components/Wordmark'
 
 export const metadata: Metadata = {
   title: 'Coming Soon | Hotdog Racing',
@@ -11,8 +12,8 @@ export default function ComingSoonPage() {
       <p className="mb-4 font-mono text-xs tracking-[0.3em] text-accent uppercase">
         Coming Soon
       </p>
-      <h1 className="mb-4 text-5xl font-bold tracking-tight text-near-white sm:text-7xl">
-        HOTDOG<span className="text-accent">RACING</span>
+      <h1 className="mb-4 text-6xl tracking-tight text-near-white sm:text-8xl">
+        <Wordmark />
       </h1>
       <p className="mb-10 max-w-sm text-base text-near-white/60">
         Setup tools and content for RC drift. Something worth waiting for.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
+import { Calistoga, Geist, Geist_Mono, Yellowtail } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react'
 import Nav from '@/components/Nav'
 import Footer from '@/components/Footer'
@@ -12,6 +12,18 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
+  subsets: ['latin'],
+})
+
+const calistoga = Calistoga({
+  variable: '--font-calistoga',
+  weight: '400',
+  subsets: ['latin'],
+})
+
+const yellowtail = Yellowtail({
+  variable: '--font-yellowtail',
+  weight: '400',
   subsets: ['latin'],
 })
 
@@ -45,7 +57,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${calistoga.variable} ${yellowtail.variable} antialiased`}
     >
       <body className="flex min-h-screen flex-col">
         <Nav />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import Sponsors from '@/components/Sponsors'
 import LatestEpisode from '@/components/LatestEpisode'
+import Wordmark from '@/components/Wordmark'
 import { EscBlueprint, GyroBlueprint, SuspensionBlueprint } from '@/components/Blueprints'
 import { fetchEpisodes, type Episode } from '@/lib/youtube/fetch'
 import { getAllPosts } from '@/lib/blog/posts'
@@ -115,7 +116,9 @@ function HeroSection() {
       </div>
       <div className="relative z-10 px-6">
         <p className="mb-4 font-mono text-xs tracking-[0.3em] text-accent-500 uppercase">RC Drift</p>
-        <h1 className="mb-4 text-5xl font-bold tracking-tight text-near-white sm:text-7xl">Hotdog Racing</h1>
+        <h1 className="mb-4 text-6xl tracking-tight text-near-white sm:text-8xl">
+          <Wordmark />
+        </h1>
         <p className="mb-8 text-lg text-near-white/60 sm:text-xl">Setup tools and content for RC drift.</p>
         <Link
           href="/tools"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,10 +1,12 @@
+import Wordmark from '@/components/Wordmark'
+
 export default function Footer() {
   const year = new Date().getFullYear()
   return (
     <footer className="border-t py-6" style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}>
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 sm:px-6">
-        <span className="text-sm" style={{ color: 'var(--muted)' }}>
-          © {year} Hotdog Racing
+        <span className="text-base" style={{ color: 'var(--muted)' }}>
+          © {year} <Wordmark />
         </span>
         <a
           href="https://www.instagram.com/hotdogracingus"

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
+import Wordmark from '@/components/Wordmark'
 
 const tools = [
   { label: 'Suspension Alignment', href: '/tools/suspension' },
@@ -45,8 +46,8 @@ export default function Nav() {
 
       <nav className="sticky top-0 z-50 w-full border-b" style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}>
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6">
-          <Link href="/" className="text-lg font-bold tracking-tight" style={{ color: 'var(--foreground)' }}>
-            HOTDOG<span className="text-accent">RACING</span>
+          <Link href="/" className="text-2xl tracking-tight" style={{ color: 'var(--foreground)' }}>
+            <Wordmark />
           </Link>
 
           {/* Desktop nav */}

--- a/components/Wordmark.tsx
+++ b/components/Wordmark.tsx
@@ -1,0 +1,13 @@
+type WordmarkProps = {
+  className?: string
+}
+
+export default function Wordmark({ className }: WordmarkProps) {
+  return (
+    <span className={className}>
+      <span style={{ fontFamily: 'var(--font-calistoga)' }}>HotDog</span>
+      {' '}
+      <span className="text-accent" style={{ fontFamily: 'var(--font-yellowtail)', fontSize: '1.4em' }}>racing</span>
+    </span>
+  )
+}


### PR DESCRIPTION
Closes #51

## Summary
- Adds the official brand fonts via `next/font/google`: **Calistoga** for "HotDog", **Yellowtail** for "racing" (in accent color).
- Extracts a single `<Wordmark />` component used in all four wordmark surfaces: nav, homepage hero, coming-soon page, and footer.
- Yellowtail is sized to `1.4em` relative to Calistoga so the script half reads at parity.

## Test plan
- [x] Vercel preview: `/` hero shows large "HotDog *racing*" wordmark
- [x] Vercel preview: sticky nav shows the wordmark top-left
- [x] Vercel preview: `/coming-soon` shows the wordmark on black
- [x] Vercel preview: footer shows "© 2026 HotDog *racing*"
- [x] Light + dark theme both legible
- [x] Mobile viewport — nav wordmark doesn't wrap or crowd the menu button