### PR TITLE
feat: suspension tool — scaffold + camber slice (#79)

### DIFF
--- a/app/tools/suspension/page.tsx
+++ b/app/tools/suspension/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+import SuspensionTool from '@/components/suspension/SuspensionTool'
+
+export const metadata: Metadata = {
+  title: 'Suspension Alignment Visualizer | Hotdog Racing',
+  description: 'Tune the parts you actually adjust on the car — lower arm length, caster spacers, hex thickness — and see camber, toe, caster, and KPI update in real time. Built for RC drift.',
+  openGraph: {
+    title: 'Suspension Alignment Visualizer | Hotdog Racing',
+    description: 'Tune the parts you actually adjust on the car and watch the alignment values update in real time.',
+    url: 'https://hotdog-racing.com/tools/suspension',
+  },
+}
+
+export default function SuspensionPage() {
+  return <SuspensionTool />
+}

--- a/components/suspension/ReadoutPanel.tsx
+++ b/components/suspension/ReadoutPanel.tsx
@@ -1,0 +1,37 @@
+import { PRECISION } from '@/lib/suspension/config'
+import type { Geometry } from '@/lib/suspension/model'
+
+type Props = {
+  geometry: Geometry
+}
+
+export default function ReadoutPanel({ geometry }: Props) {
+  return (
+    <div
+      className="w-full shrink-0 rounded-lg border p-5 lg:w-64"
+      style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+    >
+      <p className="mb-4 font-mono text-xs uppercase tracking-[0.2em]" style={{ color: 'var(--muted)' }}>
+        Alignment
+      </p>
+
+      <Readout
+        label="Camber"
+        value={`${geometry.rear.camberDeg.toFixed(PRECISION.angleDeg)}°`}
+      />
+    </div>
+  )
+}
+
+function Readout({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="mb-3 flex items-baseline justify-between">
+      <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--muted)' }}>
+        {label}
+      </span>
+      <span className="font-mono text-sm tabular-nums" style={{ color: 'var(--foreground)' }}>
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/components/suspension/RearView.tsx
+++ b/components/suspension/RearView.tsx
@@ -1,0 +1,181 @@
+import type { Geometry } from '@/lib/suspension/model'
+
+const VIEW_WIDTH = 320
+const VIEW_HEIGHT = 130
+const VIEW_X_MIN = -VIEW_WIDTH / 2
+const VIEW_Y_MIN = -110  // y-up math; ground at math y=0 lands near the bottom of the SVG
+
+type Props = {
+  geometry: Geometry
+}
+
+export default function RearView({ geometry }: Props) {
+  const { rear, chassis } = geometry
+
+  // Right side as computed; left side is mirrored across the chassis centerline.
+  const right = rear
+  const left = mirrorRear(rear)
+
+  return (
+    <svg
+      viewBox={`${VIEW_X_MIN} ${VIEW_Y_MIN} ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label="Rear view of suspension geometry"
+    >
+      <g transform="scale(1, -1)">
+        {/* Reference lines */}
+        <line
+          x1={VIEW_X_MIN}
+          y1={0}
+          x2={VIEW_X_MIN + VIEW_WIDTH}
+          y2={0}
+          stroke="currentColor"
+          strokeOpacity="0.25"
+          strokeWidth="1"
+          strokeDasharray="4 3"
+        />
+        <line
+          x1={right.wheelCenter.x}
+          y1={0}
+          x2={right.wheelCenter.x}
+          y2={Math.abs(VIEW_Y_MIN)}
+          stroke="currentColor"
+          strokeOpacity="0.25"
+          strokeWidth="1"
+          strokeDasharray="4 3"
+        />
+        <line
+          x1={left.wheelCenter.x}
+          y1={0}
+          x2={left.wheelCenter.x}
+          y2={Math.abs(VIEW_Y_MIN)}
+          stroke="currentColor"
+          strokeOpacity="0.25"
+          strokeWidth="1"
+          strokeDasharray="4 3"
+        />
+
+        {/* Lower arms */}
+        <line
+          x1={right.lowerInboard.x}
+          y1={right.lowerInboard.y}
+          x2={right.lowerOutboard.x}
+          y2={right.lowerOutboard.y}
+          stroke="currentColor"
+          strokeOpacity="0.75"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1={left.lowerInboard.x}
+          y1={left.lowerInboard.y}
+          x2={left.lowerOutboard.x}
+          y2={left.lowerOutboard.y}
+          stroke="currentColor"
+          strokeOpacity="0.75"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+
+        {/* Wheels (tire + rim) — rectangle leaning at the camber angle */}
+        <Wheel
+          centerX={right.wheelCenter.x}
+          centerY={right.wheelCenter.y}
+          camberDeg={right.camberDeg}
+          tireOD={chassis.tireOD}
+          tireWidth={chassis.tireWidth}
+          rimDiameter={chassis.rimDiameter}
+          rimWidth={chassis.rimWidth}
+        />
+        <Wheel
+          centerX={left.wheelCenter.x}
+          centerY={left.wheelCenter.y}
+          camberDeg={left.camberDeg}
+          tireOD={chassis.tireOD}
+          tireWidth={chassis.tireWidth}
+          rimDiameter={chassis.rimDiameter}
+          rimWidth={chassis.rimWidth}
+        />
+
+        {/* Pivot dots */}
+        <Pivot x={right.lowerInboard.x} y={right.lowerInboard.y} />
+        <Pivot x={right.lowerOutboard.x} y={right.lowerOutboard.y} />
+        <Pivot x={left.lowerInboard.x} y={left.lowerInboard.y} />
+        <Pivot x={left.lowerOutboard.x} y={left.lowerOutboard.y} />
+      </g>
+    </svg>
+  )
+}
+
+function Wheel({
+  centerX,
+  centerY,
+  camberDeg,
+  tireOD,
+  tireWidth,
+  rimDiameter,
+  rimWidth,
+}: {
+  centerX: number
+  centerY: number
+  camberDeg: number
+  tireOD: number
+  tireWidth: number
+  rimDiameter: number
+  rimWidth: number
+}) {
+  // Inside the y-flipped <g>, a positive math rotation is also a positive
+  // visual rotation. Camber sign convention here: positive camber tilts the
+  // top outboard; for the right wheel that's positive math angle, but the
+  // visual rotation needs to invert depending on side. We rotate the wheel
+  // around its center by the camber angle so positive camber visually tilts
+  // the top of the wheel outboard from chassis center.
+  // For the right wheel (centerX > 0), positive camber → top tilts in +x → rotate by -camberDeg around the wheel center
+  //   (because the y-axis is flipped, "rotate so top goes to +x" is a clockwise rotation in math frame).
+  // For the left wheel (centerX < 0), positive camber → top tilts in -x → rotate by +camberDeg around the center.
+  const sign = centerX >= 0 ? -1 : 1
+  const transform = `rotate(${sign * camberDeg} ${centerX} ${centerY})`
+
+  return (
+    <g transform={transform}>
+      <rect
+        x={centerX - tireWidth / 2}
+        y={centerY - tireOD / 2}
+        width={tireWidth}
+        height={tireOD}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        rx="2"
+      />
+      <rect
+        x={centerX - rimWidth / 2}
+        y={centerY - rimDiameter / 2}
+        width={rimWidth}
+        height={rimDiameter}
+        fill="none"
+        stroke="currentColor"
+        strokeOpacity="0.6"
+        strokeWidth="1.5"
+        rx="1"
+      />
+    </g>
+  )
+}
+
+function Pivot({ x, y }: { x: number; y: number }) {
+  return <circle cx={x} cy={y} r={2} fill="currentColor" />
+}
+
+function mirrorRear(rear: Geometry['rear']): Geometry['rear'] {
+  return {
+    lowerInboard: { x: -rear.lowerInboard.x, y: rear.lowerInboard.y },
+    lowerOutboard: { x: -rear.lowerOutboard.x, y: rear.lowerOutboard.y },
+    upperInboard: { x: -rear.upperInboard.x, y: rear.upperInboard.y },
+    upperOutboard: { x: -rear.upperOutboard.x, y: rear.upperOutboard.y },
+    wheelCenter: { x: -rear.wheelCenter.x, y: rear.wheelCenter.y },
+    camberDeg: rear.camberDeg,
+  }
+}

--- a/components/suspension/SetupPanel.tsx
+++ b/components/suspension/SetupPanel.tsx
@@ -1,0 +1,64 @@
+import { LOWER_ARM_LENGTH } from '@/lib/suspension/config'
+
+type Props = {
+  lowerArmLength: number
+  onLowerArmLengthChange: (value: number) => void
+}
+
+export default function SetupPanel({ lowerArmLength, onLowerArmLengthChange }: Props) {
+  return (
+    <div
+      className="w-full shrink-0 rounded-lg border p-5 lg:w-72"
+      style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+    >
+      <p className="mb-4 font-mono text-xs uppercase tracking-[0.2em]" style={{ color: 'var(--muted)' }}>
+        Setup
+      </p>
+
+      <Slider
+        label="Lower Arm Length"
+        value={lowerArmLength}
+        min={LOWER_ARM_LENGTH.min}
+        max={LOWER_ARM_LENGTH.max}
+        step={LOWER_ARM_LENGTH.step}
+        display={v => `${v.toFixed(1)} mm`}
+        onChange={onLowerArmLengthChange}
+      />
+    </div>
+  )
+}
+
+type SliderProps = {
+  label: string
+  value: number
+  min: number
+  max: number
+  step: number
+  display: (v: number) => string
+  onChange: (v: number) => void
+}
+
+function Slider({ label, value, min, max, step, display, onChange }: SliderProps) {
+  return (
+    <div className="mb-4">
+      <div className="mb-1 flex items-baseline justify-between">
+        <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--muted)' }}>
+          {label}
+        </span>
+        <span className="font-mono text-sm" style={{ color: 'var(--foreground)' }}>
+          {display(value)}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={e => onChange(parseFloat(e.target.value))}
+        className="w-full"
+        style={{ accentColor: '#FF0020' }}
+      />
+    </div>
+  )
+}

--- a/components/suspension/StatePanel.tsx
+++ b/components/suspension/StatePanel.tsx
@@ -1,0 +1,19 @@
+// Stub for the state slider region (steering input, L/R wheel travel).
+// State sliders land in #84; this placeholder keeps the responsive shell
+// honest by reserving the bottom-docked region across all breakpoints.
+
+export default function StatePanel() {
+  return (
+    <div
+      className="w-full rounded-lg border p-3"
+      style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+    >
+      <p className="font-mono text-xs uppercase tracking-[0.2em]" style={{ color: 'var(--muted)' }}>
+        State
+      </p>
+      <p className="mt-1 text-xs" style={{ color: 'var(--muted)' }}>
+        Steering & travel sliders coming in a later slice.
+      </p>
+    </div>
+  )
+}

--- a/components/suspension/SuspensionTool.tsx
+++ b/components/suspension/SuspensionTool.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { LOWER_ARM_LENGTH } from '@/lib/suspension/config'
+import { computeGeometry } from '@/lib/suspension/model'
+import RearView from './RearView'
+import TopView from './TopView'
+import SetupPanel from './SetupPanel'
+import ReadoutPanel from './ReadoutPanel'
+import StatePanel from './StatePanel'
+
+export default function SuspensionTool() {
+  const [lowerArmLength, setLowerArmLength] = useState(LOWER_ARM_LENGTH.defaultValue)
+
+  const geometry = useMemo(
+    () => computeGeometry({ lowerArmLength }),
+    [lowerArmLength],
+  )
+
+  return (
+    <section className="px-4 py-8 sm:px-6">
+      <div className="mx-auto max-w-7xl">
+        <p className="mb-1 font-mono text-xs uppercase tracking-[0.25em] text-accent">Suspension Tool</p>
+        <h1 className="mb-6 text-2xl font-bold sm:text-3xl" style={{ color: 'var(--foreground)' }}>
+          Suspension Alignment Visualizer
+        </h1>
+
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+          <SetupPanel
+            lowerArmLength={lowerArmLength}
+            onLowerArmLengthChange={setLowerArmLength}
+          />
+
+          <div className="flex flex-1 flex-col gap-4">
+            <div
+              className="overflow-hidden rounded-lg border"
+              style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+            >
+              <div className="border-b px-4 py-2" style={{ borderColor: 'var(--border)' }}>
+                <p className="font-mono text-xs uppercase tracking-[0.2em]" style={{ color: 'var(--muted)' }}>
+                  Top View
+                </p>
+              </div>
+              <div className="aspect-[16/10] w-full" style={{ color: 'var(--foreground)' }}>
+                <TopView geometry={geometry} />
+              </div>
+            </div>
+
+            <div
+              className="overflow-hidden rounded-lg border"
+              style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+            >
+              <div className="border-b px-4 py-2" style={{ borderColor: 'var(--border)' }}>
+                <p className="font-mono text-xs uppercase tracking-[0.2em]" style={{ color: 'var(--muted)' }}>
+                  Rear View
+                </p>
+              </div>
+              <div className="aspect-[16/7] w-full" style={{ color: 'var(--foreground)' }}>
+                <RearView geometry={geometry} />
+              </div>
+            </div>
+          </div>
+
+          <ReadoutPanel geometry={geometry} />
+        </div>
+
+        <div className="mt-4">
+          <StatePanel />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/suspension/TopView.tsx
+++ b/components/suspension/TopView.tsx
@@ -1,0 +1,119 @@
+import type { Geometry } from '@/lib/suspension/model'
+
+const VIEW_WIDTH = 320
+const VIEW_HEIGHT = 200
+const VIEW_X_MIN = -VIEW_WIDTH / 2
+const VIEW_Y_MIN = -VIEW_HEIGHT / 2
+
+type Props = {
+  geometry: Geometry
+}
+
+export default function TopView({ geometry }: Props) {
+  const { top, chassis } = geometry
+
+  const right = top
+  const left: typeof top = {
+    lowerInboard: { x: -top.lowerInboard.x, y: top.lowerInboard.y },
+    lowerOutboard: { x: -top.lowerOutboard.x, y: top.lowerOutboard.y },
+    wheelCenter: { x: -top.wheelCenter.x, y: top.wheelCenter.y },
+  }
+
+  return (
+    <svg
+      viewBox={`${VIEW_X_MIN} ${VIEW_Y_MIN} ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+      className="block h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label="Top view of suspension geometry"
+    >
+      {/* Chassis centerline */}
+      <line
+        x1={0}
+        y1={VIEW_Y_MIN}
+        x2={0}
+        y2={VIEW_Y_MIN + VIEW_HEIGHT}
+        stroke="currentColor"
+        strokeOpacity="0.25"
+        strokeWidth="1"
+        strokeDasharray="4 3"
+      />
+
+      {/* Lower arms (top-down projection — purely lateral in v1) */}
+      <line
+        x1={right.lowerInboard.x}
+        y1={right.lowerInboard.y}
+        x2={right.lowerOutboard.x}
+        y2={right.lowerOutboard.y}
+        stroke="currentColor"
+        strokeOpacity="0.75"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <line
+        x1={left.lowerInboard.x}
+        y1={left.lowerInboard.y}
+        x2={left.lowerOutboard.x}
+        y2={left.lowerOutboard.y}
+        stroke="currentColor"
+        strokeOpacity="0.75"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+
+      {/* Wheel footprints */}
+      <Wheel center={right.wheelCenter} tireWidth={chassis.tireWidth} tireOD={chassis.tireOD} rimWidth={chassis.rimWidth} rimOD={chassis.rimDiameter} />
+      <Wheel center={left.wheelCenter} tireWidth={chassis.tireWidth} tireOD={chassis.tireOD} rimWidth={chassis.rimWidth} rimOD={chassis.rimDiameter} />
+
+      {/* Pivot dots */}
+      <Pivot x={right.lowerInboard.x} y={right.lowerInboard.y} />
+      <Pivot x={right.lowerOutboard.x} y={right.lowerOutboard.y} />
+      <Pivot x={left.lowerInboard.x} y={left.lowerInboard.y} />
+      <Pivot x={left.lowerOutboard.x} y={left.lowerOutboard.y} />
+    </svg>
+  )
+}
+
+function Wheel({
+  center,
+  tireWidth,
+  tireOD,
+  rimWidth,
+  rimOD,
+}: {
+  center: { x: number; y: number }
+  tireWidth: number
+  tireOD: number
+  rimWidth: number
+  rimOD: number
+}) {
+  return (
+    <g>
+      <rect
+        x={center.x - tireWidth / 2}
+        y={center.y - tireOD / 2}
+        width={tireWidth}
+        height={tireOD}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        rx="2"
+      />
+      <rect
+        x={center.x - rimWidth / 2}
+        y={center.y - rimOD / 2}
+        width={rimWidth}
+        height={rimOD}
+        fill="none"
+        stroke="currentColor"
+        strokeOpacity="0.6"
+        strokeWidth="1.5"
+        rx="1"
+      />
+    </g>
+  )
+}
+
+function Pivot({ x, y }: { x: number; y: number }) {
+  return <circle cx={x} cy={y} r={2} fill="currentColor" />
+}

--- a/lib/suspension/config.ts
+++ b/lib/suspension/config.ts
@@ -1,0 +1,56 @@
+// Slider ranges, defaults, step sizes, baseline chassis values, and decimal
+// precision for the suspension tool. All baseline values are placeholders
+// pinned with TODO until measured against a reference 1/10 MR chassis.
+
+export type SliderDef = {
+  min: number
+  max: number
+  step: number
+  defaultValue: number
+}
+
+export type ChassisBaseline = {
+  // Rear-view plane (y = 0 is ground, +y up, +x is outboard from chassis centerline).
+  // Right side of the car; left side mirrors.
+  blockLowerInboardX: number
+  blockLowerY: number
+  blockUpperInboardX: number
+  blockUpperY: number
+  knuckleLength: number       // distance between lower and upper kingpin balls along the carrier
+  upperArmLength: number      // chassis-fixed in v1 (the Advanced panel slider lands in #89)
+  // Temporary placeholder pinning the 4-bar linkage's free DOF until the
+  // Ride height slider (PRD Setup table) is wired up — at that point ride
+  // height will determine the lower-arm angle and this field can be removed.
+  staticLowerArmAngleDeg: number
+  // Visualization-only baseline; these gain dedicated sliders in #82.
+  tireOD: number
+  tireWidth: number
+  rimDiameter: number
+  rimWidth: number
+}
+
+// Driver-tunable
+export const LOWER_ARM_LENGTH: SliderDef = { min: 35, max: 60, step: 0.5, defaultValue: 45 }
+
+// Chassis baseline. Engineered so that at default LOWER_ARM_LENGTH the kingpin is
+// vertical (camber = 0°) and the wheel sits with its bottom at ground.
+export const CHASSIS_BASELINE: ChassisBaseline = {
+  blockLowerInboardX: 25,        // TODO: measure off reference chassis
+  blockLowerY: 8,                // TODO
+  blockUpperInboardX: 25,        // TODO
+  blockUpperY: 53,               // TODO
+  knuckleLength: 45,             // TODO
+  upperArmLength: 45,            // TODO
+  staticLowerArmAngleDeg: 0,     // TODO — currently horizontal
+  tireOD: 60,                    // TODO
+  tireWidth: 24,                 // TODO
+  rimDiameter: 35,               // TODO
+  rimWidth: 18,                  // TODO
+}
+
+// Decimal precision for readouts (per PRD: 0.1° / 0.1mm / integer %)
+export const PRECISION = {
+  angleDeg: 1,    // 0.1° — one decimal place
+  lengthMm: 1,    // 0.1mm
+  percent: 0,     // integer %
+} as const

--- a/lib/suspension/model.test.ts
+++ b/lib/suspension/model.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { computeGeometry } from './model'
+import { CHASSIS_BASELINE, LOWER_ARM_LENGTH } from './config'
+
+describe('computeGeometry — camber', () => {
+  it('returns zero camber at the baseline lower arm length (kingpin vertical)', () => {
+    const geo = computeGeometry({ lowerArmLength: LOWER_ARM_LENGTH.defaultValue })
+    expect(geo.rear.camberDeg).toBeCloseTo(0, 5)
+  })
+
+  it('returns negative camber when the lower arm is lengthened (top tilts inboard)', () => {
+    // Hand-computed: lowerArmLength = 50, baseline chassis, gives camber ≈ -6.38°
+    const geo = computeGeometry({ lowerArmLength: 50 })
+    expect(geo.rear.camberDeg).toBeCloseTo(-6.38, 1)
+    expect(geo.rear.camberDeg).toBeLessThan(0)
+  })
+
+  it('returns positive camber when the lower arm is shortened (top tilts outboard)', () => {
+    // Hand-computed: lowerArmLength = 40, baseline chassis, gives camber ≈ +6.38°
+    const geo = computeGeometry({ lowerArmLength: 40 })
+    expect(geo.rear.camberDeg).toBeCloseTo(6.38, 1)
+    expect(geo.rear.camberDeg).toBeGreaterThan(0)
+  })
+
+  it('is monotonically decreasing as lower arm length increases (across the valid range)', () => {
+    const lengths = [LOWER_ARM_LENGTH.min, 40, 42.5, 45, 47.5, 50, 55, LOWER_ARM_LENGTH.max]
+    const cambers = lengths.map(l => computeGeometry({ lowerArmLength: l }).rear.camberDeg)
+    for (let i = 1; i < cambers.length; i++) {
+      expect(cambers[i]).toBeLessThan(cambers[i - 1])
+    }
+  })
+})
+
+describe('computeGeometry — outboard kingpin ball position', () => {
+  it('places the lower outboard ball at lowerArmLength from the inboard pivot (horizontal arm)', () => {
+    const geo = computeGeometry({ lowerArmLength: 45 })
+    expect(geo.rear.lowerOutboard.x).toBeCloseTo(CHASSIS_BASELINE.blockLowerInboardX + 45, 5)
+    expect(geo.rear.lowerOutboard.y).toBeCloseTo(CHASSIS_BASELINE.blockLowerY, 5)
+  })
+
+  it('places the upper outboard ball such that knuckle length and upper arm length are both satisfied', () => {
+    const geo = computeGeometry({ lowerArmLength: 50 })
+    const dKnuckle = Math.hypot(
+      geo.rear.upperOutboard.x - geo.rear.lowerOutboard.x,
+      geo.rear.upperOutboard.y - geo.rear.lowerOutboard.y,
+    )
+    const dUpperArm = Math.hypot(
+      geo.rear.upperOutboard.x - geo.rear.upperInboard.x,
+      geo.rear.upperOutboard.y - geo.rear.upperInboard.y,
+    )
+    expect(dKnuckle).toBeCloseTo(CHASSIS_BASELINE.knuckleLength, 5)
+    expect(dUpperArm).toBeCloseTo(CHASSIS_BASELINE.upperArmLength, 5)
+  })
+})
+
+describe('computeGeometry — top view', () => {
+  it('places top-view points at y = 0 (forward axis is zero in the v1 slice)', () => {
+    const geo = computeGeometry({ lowerArmLength: 45 })
+    expect(geo.top.lowerInboard.y).toBe(0)
+    expect(geo.top.lowerOutboard.y).toBe(0)
+    expect(geo.top.wheelCenter.y).toBe(0)
+  })
+
+  it('mirrors the rear-view x positions onto the top view', () => {
+    const geo = computeGeometry({ lowerArmLength: 50 })
+    expect(geo.top.lowerOutboard.x).toBeCloseTo(geo.rear.lowerOutboard.x, 5)
+    expect(geo.top.wheelCenter.x).toBeCloseTo(geo.rear.wheelCenter.x, 5)
+  })
+})
+
+describe('computeGeometry — robustness', () => {
+  it('does not throw at the slider range extremes', () => {
+    expect(() => computeGeometry({ lowerArmLength: LOWER_ARM_LENGTH.min })).not.toThrow()
+    expect(() => computeGeometry({ lowerArmLength: LOWER_ARM_LENGTH.max })).not.toThrow()
+  })
+
+  it('returns finite numbers across the valid range', () => {
+    for (let l = LOWER_ARM_LENGTH.min; l <= LOWER_ARM_LENGTH.max; l += 1) {
+      const geo = computeGeometry({ lowerArmLength: l })
+      expect(Number.isFinite(geo.rear.camberDeg)).toBe(true)
+      expect(Number.isFinite(geo.rear.upperOutboard.x)).toBe(true)
+      expect(Number.isFinite(geo.rear.upperOutboard.y)).toBe(true)
+    }
+  })
+})

--- a/lib/suspension/model.ts
+++ b/lib/suspension/model.ts
@@ -1,0 +1,123 @@
+// Pure suspension geometry. Decoupled 2D per the PRD: rear plane and top plane
+// are self-contained; cross-plane "bridge" functions land in later slices.
+// No React imports, no side effects.
+
+import { CHASSIS_BASELINE } from './config'
+import type { ChassisBaseline } from './config'
+
+export type Point = { x: number; y: number }
+
+export type Setup = {
+  lowerArmLength: number
+}
+
+export type RearGeometry = {
+  lowerInboard: Point
+  lowerOutboard: Point
+  upperInboard: Point
+  upperOutboard: Point
+  wheelCenter: Point
+  camberDeg: number  // signed: positive = wheel top tilts outboard, negative = top tilts inboard
+}
+
+export type TopGeometry = {
+  // Top-view positions of the lower arm endpoints, projected (forward axis = 0 in v1).
+  lowerInboard: Point
+  lowerOutboard: Point
+  wheelCenter: Point
+}
+
+export type Geometry = {
+  rear: RearGeometry
+  top: TopGeometry
+  chassis: ChassisBaseline  // exposed so renderers can size wheels, rims, etc.
+}
+
+// Intersect two circles in 2D. Returns the intersection point on the side
+// preferred (greater x for 'outboard', smaller x for 'inboard'). Falls back
+// to the line connecting the centers when the circles don't intersect, so
+// we degrade gracefully on out-of-reach inputs (proper GeometryError lands in #86).
+function circleCircleIntersect(
+  c1: Point,
+  r1: number,
+  c2: Point,
+  r2: number,
+  prefer: 'outboard' | 'inboard',
+): Point {
+  const dx = c2.x - c1.x
+  const dy = c2.y - c1.y
+  const d = Math.hypot(dx, dy)
+
+  if (d === 0 || d > r1 + r2 || d < Math.abs(r1 - r2)) {
+    // Out of reach — return the closest point on c2's circle from c1's direction.
+    const ux = d === 0 ? 1 : dx / d
+    const uy = d === 0 ? 0 : dy / d
+    return { x: c1.x + r1 * ux, y: c1.y + r1 * uy }
+  }
+
+  const a = (r1 * r1 - r2 * r2 + d * d) / (2 * d)
+  const h = Math.sqrt(Math.max(0, r1 * r1 - a * a))
+  const mx = c1.x + (a * dx) / d
+  const my = c1.y + (a * dy) / d
+  const ox = (h * dy) / d
+  const oy = (h * dx) / d
+
+  const p1 = { x: mx + ox, y: my - oy }
+  const p2 = { x: mx - ox, y: my + oy }
+  if (prefer === 'outboard') return p1.x >= p2.x ? p1 : p2
+  return p1.x <= p2.x ? p1 : p2
+}
+
+function computeRearGeometry(setup: Setup, chassis: ChassisBaseline): RearGeometry {
+  const lowerInboard: Point = { x: chassis.blockLowerInboardX, y: chassis.blockLowerY }
+  const upperInboard: Point = { x: chassis.blockUpperInboardX, y: chassis.blockUpperY }
+
+  const armAngleRad = (chassis.staticLowerArmAngleDeg * Math.PI) / 180
+  const lowerOutboard: Point = {
+    x: lowerInboard.x + setup.lowerArmLength * Math.cos(armAngleRad),
+    y: lowerInboard.y + setup.lowerArmLength * Math.sin(armAngleRad),
+  }
+
+  const upperOutboard = circleCircleIntersect(
+    upperInboard,
+    chassis.upperArmLength,
+    lowerOutboard,
+    chassis.knuckleLength,
+    'outboard',
+  )
+
+  const dx = upperOutboard.x - lowerOutboard.x
+  const dy = upperOutboard.y - lowerOutboard.y
+  // atan2(dx, dy): zero when kingpin is vertical (dx=0, dy>0).
+  // Negative when upper ball is inboard of lower ball (top of wheel tilts in → negative camber by RC convention).
+  const camberDeg = Math.atan2(dx, dy) * (180 / Math.PI)
+
+  // Wheel center sits on the kingpin axis at the midpoint between the two balls in v1.
+  // Scrub-radius offset (lateral wheel offset from kingpin) lands in #82.
+  const wheelCenter: Point = {
+    x: (lowerOutboard.x + upperOutboard.x) / 2,
+    y: (lowerOutboard.y + upperOutboard.y) / 2,
+  }
+
+  return { lowerInboard, lowerOutboard, upperInboard, upperOutboard, wheelCenter, camberDeg }
+}
+
+function computeTopGeometry(rear: RearGeometry): TopGeometry {
+  // v1 top-view projection: lower arm runs purely laterally at the wheel's
+  // longitudinal position (y = 0). Forward sweep / steering-induced rotation
+  // lands in #80 (steering & toe).
+  return {
+    lowerInboard: { x: rear.lowerInboard.x, y: 0 },
+    lowerOutboard: { x: rear.lowerOutboard.x, y: 0 },
+    wheelCenter: { x: rear.wheelCenter.x, y: 0 },
+  }
+}
+
+export function computeGeometry(
+  setup: Setup,
+  chassis: ChassisBaseline = CHASSIS_BASELINE,
+): Geometry {
+  const rear = computeRearGeometry(setup, chassis)
+  const top = computeTopGeometry(rear)
+  return { rear, top, chassis }
+}


### PR DESCRIPTION
## Summary

Tracer-bullet foundation for the Suspension Alignment Visualizer (PRD: `docs/suspension-tool-prd.md`):

- New route `/tools/suspension` with Open Graph metadata; tools nav and `/tools` index already point at it
- File structure scaffolded per the spec: `lib/suspension/{model,config}.ts` for pure geometry math, `components/suspension/{SuspensionTool,TopView,RearView,SetupPanel,ReadoutPanel,StatePanel}.tsx` for the assembly + rendering split (mirrors the ESC tool's separation)
- End-to-end pipeline through a single alignment dimension: **Lower Arm Length** slider → 2D 4-bar linkage solve (lower arm + upper arm + knuckle, fixed inboard pivots) → camber readout, with a top + rear wireframe rendering wheels and lower A-arms reactively
- Unit tests cover camber at hand-computed inputs (45 mm baseline → 0°, 50 mm → −6.4°, 40 mm → +6.4°), monotonicity across the valid range, knuckle / upper-arm constraint validation, and range-extreme robustness

## Notes

- One stand-in: `staticLowerArmAngleDeg` in the chassis baseline pins the 4-bar's free DOF until the Ride Height slider lands (PRD's Setup table). It's flagged with a comment in `config.ts` and goes away when ride height enters a future slice.
- `computeGeometry` returns `Geometry` directly (not `Result<Geometry, GeometryError>`); the discriminated-union refactor is #86's job per its brief.
- Sticky mobile layout polish, full color-scheme audit, and tooltips land in #90.

## Test plan

- [ ] Vercel preview: `/tools/suspension` reachable from Tools dropdown and `/tools` index
- [ ] At default Lower Arm Length (45 mm), camber reads `0.0°` and rear-view kingpin is vertical
- [ ] Dragging the slider longer → camber goes negative (top tilts inboard); shorter → positive (top tilts outboard); both wheels mirror
- [ ] Wireframe color scheme reads correctly in light + dark mode (tire 2.5px solid, lower arms 75% / 2px, reference lines 25% / 1px dashed)
- [ ] Mobile viewport (~375px) — panels stack, wireframes scale to width without cropping
- [ ] Slider range extremes (35 mm / 60 mm) don't break rendering or produce NaN in the readout
- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes (only pre-existing `<img>` warnings in `app/about/page.tsx` and `components/Sponsors.tsx`)
- [x] `npx vitest run` passes (10 new suspension tests, 79 total)

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)