### PR TITLE
feat: suspension tool — steering & toe slice (#80)

### DIFF
--- a/components/suspension/ReadoutPanel.tsx
+++ b/components/suspension/ReadoutPanel.tsx
@@ -19,6 +19,14 @@ export default function ReadoutPanel({ geometry }: Props) {
         label="Camber"
         value={`${geometry.rear.camberDeg.toFixed(PRECISION.angleDeg)}°`}
       />
+      <Readout
+        label="Toe (L)"
+        value={`${geometry.top.toeDegLeft.toFixed(PRECISION.angleDeg)}°`}
+      />
+      <Readout
+        label="Toe (R)"
+        value={`${geometry.top.toeDegRight.toFixed(PRECISION.angleDeg)}°`}
+      />
     </div>
   )
 }

--- a/components/suspension/SetupPanel.tsx
+++ b/components/suspension/SetupPanel.tsx
@@ -1,11 +1,18 @@
-import { LOWER_ARM_LENGTH } from '@/lib/suspension/config'
+import { LOWER_ARM_LENGTH, TIE_ROD_LENGTH } from '@/lib/suspension/config'
 
 type Props = {
   lowerArmLength: number
   onLowerArmLengthChange: (value: number) => void
+  tieRodLength: number
+  onTieRodLengthChange: (value: number) => void
 }
 
-export default function SetupPanel({ lowerArmLength, onLowerArmLengthChange }: Props) {
+export default function SetupPanel({
+  lowerArmLength,
+  onLowerArmLengthChange,
+  tieRodLength,
+  onTieRodLengthChange,
+}: Props) {
   return (
     <div
       className="w-full shrink-0 rounded-lg border p-5 lg:w-72"
@@ -23,6 +30,16 @@ export default function SetupPanel({ lowerArmLength, onLowerArmLengthChange }: P
         step={LOWER_ARM_LENGTH.step}
         display={v => `${v.toFixed(1)} mm`}
         onChange={onLowerArmLengthChange}
+      />
+
+      <Slider
+        label="Tie Rod Length"
+        value={tieRodLength}
+        min={TIE_ROD_LENGTH.min}
+        max={TIE_ROD_LENGTH.max}
+        step={TIE_ROD_LENGTH.step}
+        display={v => `${v.toFixed(1)} mm`}
+        onChange={onTieRodLengthChange}
       />
     </div>
   )

--- a/components/suspension/SuspensionTool.tsx
+++ b/components/suspension/SuspensionTool.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { LOWER_ARM_LENGTH } from '@/lib/suspension/config'
+import { LOWER_ARM_LENGTH, TIE_ROD_LENGTH } from '@/lib/suspension/config'
 import { computeGeometry } from '@/lib/suspension/model'
 import RearView from './RearView'
 import TopView from './TopView'
@@ -11,10 +11,11 @@ import StatePanel from './StatePanel'
 
 export default function SuspensionTool() {
   const [lowerArmLength, setLowerArmLength] = useState(LOWER_ARM_LENGTH.defaultValue)
+  const [tieRodLength, setTieRodLength] = useState(TIE_ROD_LENGTH.defaultValue)
 
   const geometry = useMemo(
-    () => computeGeometry({ lowerArmLength }),
-    [lowerArmLength],
+    () => computeGeometry({ lowerArmLength, tieRodLength }),
+    [lowerArmLength, tieRodLength],
   )
 
   return (
@@ -29,6 +30,8 @@ export default function SuspensionTool() {
           <SetupPanel
             lowerArmLength={lowerArmLength}
             onLowerArmLengthChange={setLowerArmLength}
+            tieRodLength={tieRodLength}
+            onTieRodLengthChange={setTieRodLength}
           />
 
           <div className="flex flex-1 flex-col gap-4">

--- a/components/suspension/TopView.tsx
+++ b/components/suspension/TopView.tsx
@@ -9,16 +9,28 @@ type Props = {
   geometry: Geometry
 }
 
+const STEERING_RED = '#FF0020'
+
 export default function TopView({ geometry }: Props) {
   const { top, chassis } = geometry
 
-  const right = top
-  const left: typeof top = {
-    lowerInboard: { x: -top.lowerInboard.x, y: top.lowerInboard.y },
-    lowerOutboard: { x: -top.lowerOutboard.x, y: top.lowerOutboard.y },
-    wheelCenter: { x: -top.wheelCenter.x, y: top.wheelCenter.y },
+  const right = {
+    lowerInboard: top.lowerInboard,
+    lowerOutboard: top.lowerOutboard,
+    wheelCenter: top.wheelCenter,
+    rackBall: top.rackBall,
+    tieRodOutboard: top.tieRodOutboard,
+  }
+  const left = {
+    lowerInboard: mirrorX(top.lowerInboard),
+    lowerOutboard: mirrorX(top.lowerOutboard),
+    wheelCenter: mirrorX(top.wheelCenter),
+    rackBall: mirrorX(top.rackBall),
+    tieRodOutboard: mirrorX(top.tieRodOutboard),
   }
 
+  // SVG y is flipped relative to math y (+ y math = forward). Group flip lets
+  // children use math coords directly so visual "forward" stays at the top.
   return (
     <svg
       viewBox={`${VIEW_X_MIN} ${VIEW_Y_MIN} ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
@@ -27,49 +39,102 @@ export default function TopView({ geometry }: Props) {
       role="img"
       aria-label="Top view of suspension geometry"
     >
-      {/* Chassis centerline */}
-      <line
-        x1={0}
-        y1={VIEW_Y_MIN}
-        x2={0}
-        y2={VIEW_Y_MIN + VIEW_HEIGHT}
-        stroke="currentColor"
-        strokeOpacity="0.25"
-        strokeWidth="1"
-        strokeDasharray="4 3"
-      />
+      <g transform="scale(1, -1)">
+        {/* Chassis centerline */}
+        <line
+          x1={0}
+          y1={VIEW_Y_MIN}
+          x2={0}
+          y2={VIEW_Y_MIN + VIEW_HEIGHT}
+          stroke="currentColor"
+          strokeOpacity="0.25"
+          strokeWidth="1"
+          strokeDasharray="4 3"
+        />
 
-      {/* Lower arms (top-down projection — purely lateral in v1) */}
-      <line
-        x1={right.lowerInboard.x}
-        y1={right.lowerInboard.y}
-        x2={right.lowerOutboard.x}
-        y2={right.lowerOutboard.y}
-        stroke="currentColor"
-        strokeOpacity="0.75"
-        strokeWidth="2"
-        strokeLinecap="round"
-      />
-      <line
-        x1={left.lowerInboard.x}
-        y1={left.lowerInboard.y}
-        x2={left.lowerOutboard.x}
-        y2={left.lowerOutboard.y}
-        stroke="currentColor"
-        strokeOpacity="0.75"
-        strokeWidth="2"
-        strokeLinecap="round"
-      />
+        {/* Lower arms (top-down projection — purely lateral in v1) */}
+        <line
+          x1={right.lowerInboard.x}
+          y1={right.lowerInboard.y}
+          x2={right.lowerOutboard.x}
+          y2={right.lowerOutboard.y}
+          stroke="currentColor"
+          strokeOpacity="0.75"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1={left.lowerInboard.x}
+          y1={left.lowerInboard.y}
+          x2={left.lowerOutboard.x}
+          y2={left.lowerOutboard.y}
+          stroke="currentColor"
+          strokeOpacity="0.75"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
 
-      {/* Wheel footprints */}
-      <Wheel center={right.wheelCenter} tireWidth={chassis.tireWidth} tireOD={chassis.tireOD} rimWidth={chassis.rimWidth} rimOD={chassis.rimDiameter} />
-      <Wheel center={left.wheelCenter} tireWidth={chassis.tireWidth} tireOD={chassis.tireOD} rimWidth={chassis.rimWidth} rimOD={chassis.rimDiameter} />
+        {/* Wheel footprints — rotated by toe so steering changes are visible.
+            Sign flips per side so positive toe (toe in) tilts both wheel fronts
+            toward the chassis centerline. */}
+        <Wheel
+          center={right.wheelCenter}
+          tireWidth={chassis.tireWidth}
+          tireOD={chassis.tireOD}
+          rimWidth={chassis.rimWidth}
+          rimOD={chassis.rimDiameter}
+          toeDeg={top.toeDegRight}
+        />
+        <Wheel
+          center={left.wheelCenter}
+          tireWidth={chassis.tireWidth}
+          tireOD={chassis.tireOD}
+          rimWidth={chassis.rimWidth}
+          rimOD={chassis.rimDiameter}
+          toeDeg={-top.toeDegLeft}
+        />
 
-      {/* Pivot dots */}
-      <Pivot x={right.lowerInboard.x} y={right.lowerInboard.y} />
-      <Pivot x={right.lowerOutboard.x} y={right.lowerOutboard.y} />
-      <Pivot x={left.lowerInboard.x} y={left.lowerInboard.y} />
-      <Pivot x={left.lowerOutboard.x} y={left.lowerOutboard.y} />
+        {/* Steering rack — connects the two rack balls laterally */}
+        <line
+          x1={left.rackBall.x}
+          y1={left.rackBall.y}
+          x2={right.rackBall.x}
+          y2={right.rackBall.y}
+          stroke={STEERING_RED}
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+
+        {/* Tie rods — rack ball to knuckle outboard pickup */}
+        <line
+          x1={right.rackBall.x}
+          y1={right.rackBall.y}
+          x2={right.tieRodOutboard.x}
+          y2={right.tieRodOutboard.y}
+          stroke={STEERING_RED}
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1={left.rackBall.x}
+          y1={left.rackBall.y}
+          x2={left.tieRodOutboard.x}
+          y2={left.tieRodOutboard.y}
+          stroke={STEERING_RED}
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+
+        {/* Pivot dots */}
+        <Pivot x={right.lowerInboard.x} y={right.lowerInboard.y} />
+        <Pivot x={right.lowerOutboard.x} y={right.lowerOutboard.y} />
+        <Pivot x={left.lowerInboard.x} y={left.lowerInboard.y} />
+        <Pivot x={left.lowerOutboard.x} y={left.lowerOutboard.y} />
+        <Pivot x={right.rackBall.x} y={right.rackBall.y} />
+        <Pivot x={left.rackBall.x} y={left.rackBall.y} />
+        <Pivot x={right.tieRodOutboard.x} y={right.tieRodOutboard.y} />
+        <Pivot x={left.tieRodOutboard.x} y={left.tieRodOutboard.y} />
+      </g>
     </svg>
   )
 }
@@ -80,15 +145,22 @@ function Wheel({
   tireOD,
   rimWidth,
   rimOD,
+  toeDeg,
 }: {
   center: { x: number; y: number }
   tireWidth: number
   tireOD: number
   rimWidth: number
   rimOD: number
+  toeDeg: number
 }) {
+  // Inside the y-flipped parent, a positive math rotation around (cx, cy)
+  // is also a positive visual rotation. Toe convention: positive = toe in =
+  // front of wheel toward chassis centerline. For the right wheel that's a
+  // CCW rotation about the kingpin (top-down), which matches +toeDeg directly.
+  const transform = `rotate(${toeDeg} ${center.x} ${center.y})`
   return (
-    <g>
+    <g transform={transform}>
       <rect
         x={center.x - tireWidth / 2}
         y={center.y - tireOD / 2}
@@ -116,4 +188,8 @@ function Wheel({
 
 function Pivot({ x, y }: { x: number; y: number }) {
   return <circle cx={x} cy={y} r={2} fill="currentColor" />
+}
+
+function mirrorX(p: { x: number; y: number }) {
+  return { x: -p.x, y: p.y }
 }

--- a/lib/suspension/config.ts
+++ b/lib/suspension/config.ts
@@ -27,10 +27,18 @@ export type ChassisBaseline = {
   tireWidth: number
   rimDiameter: number
   rimWidth: number
+  // Top-view plane (y = +forward, x = +outboard right; left mirrors).
+  // Steering geometry. Engineered so that at default LOWER_ARM_LENGTH and default
+  // TIE_ROD_LENGTH the right-side knuckle sits at zero rotation (zero toe).
+  rackBallX: number              // rack ball x position (right side; left mirrors)
+  rackBallY: number              // rack ball y position (negative = behind front axle)
+  knuckleTieRodOffsetX: number   // tie rod attach offset from kingpin in baseline knuckle frame
+  knuckleTieRodOffsetY: number
 }
 
 // Driver-tunable
 export const LOWER_ARM_LENGTH: SliderDef = { min: 35, max: 60, step: 0.5, defaultValue: 45 }
+export const TIE_ROD_LENGTH: SliderDef = { min: 30, max: 50, step: 0.5, defaultValue: 40 }
 
 // Chassis baseline. Engineered so that at default LOWER_ARM_LENGTH the kingpin is
 // vertical (camber = 0°) and the wheel sits with its bottom at ground.
@@ -46,6 +54,13 @@ export const CHASSIS_BASELINE: ChassisBaseline = {
   tireWidth: 24,                 // TODO
   rimDiameter: 35,               // TODO
   rimWidth: 18,                  // TODO
+  // Top-view steering geometry — at default lowerArm=45 the right kingpin sits
+  // at top-view (70, 0); knuckle attach baseline is (60, -10); rack ball at
+  // (20, -10) gives a 40mm tie rod for zero toe at TIE_ROD_LENGTH.defaultValue.
+  rackBallX: 20,                 // TODO
+  rackBallY: -10,                // TODO
+  knuckleTieRodOffsetX: -10,     // TODO
+  knuckleTieRodOffsetY: -10,     // TODO
 }
 
 // Decimal precision for readouts (per PRD: 0.1° / 0.1mm / integer %)

--- a/lib/suspension/model.test.ts
+++ b/lib/suspension/model.test.ts
@@ -1,30 +1,36 @@
 import { describe, it, expect } from 'vitest'
 import { computeGeometry } from './model'
-import { CHASSIS_BASELINE, LOWER_ARM_LENGTH } from './config'
+import { CHASSIS_BASELINE, LOWER_ARM_LENGTH, TIE_ROD_LENGTH } from './config'
+import type { ChassisBaseline } from './config'
+
+const DEFAULTS = {
+  lowerArmLength: LOWER_ARM_LENGTH.defaultValue,
+  tieRodLength: TIE_ROD_LENGTH.defaultValue,
+}
 
 describe('computeGeometry — camber', () => {
   it('returns zero camber at the baseline lower arm length (kingpin vertical)', () => {
-    const geo = computeGeometry({ lowerArmLength: LOWER_ARM_LENGTH.defaultValue })
+    const geo = computeGeometry({ ...DEFAULTS })
     expect(geo.rear.camberDeg).toBeCloseTo(0, 5)
   })
 
   it('returns negative camber when the lower arm is lengthened (top tilts inboard)', () => {
     // Hand-computed: lowerArmLength = 50, baseline chassis, gives camber ≈ -6.38°
-    const geo = computeGeometry({ lowerArmLength: 50 })
+    const geo = computeGeometry({ ...DEFAULTS, lowerArmLength: 50 })
     expect(geo.rear.camberDeg).toBeCloseTo(-6.38, 1)
     expect(geo.rear.camberDeg).toBeLessThan(0)
   })
 
   it('returns positive camber when the lower arm is shortened (top tilts outboard)', () => {
     // Hand-computed: lowerArmLength = 40, baseline chassis, gives camber ≈ +6.38°
-    const geo = computeGeometry({ lowerArmLength: 40 })
+    const geo = computeGeometry({ ...DEFAULTS, lowerArmLength: 40 })
     expect(geo.rear.camberDeg).toBeCloseTo(6.38, 1)
     expect(geo.rear.camberDeg).toBeGreaterThan(0)
   })
 
   it('is monotonically decreasing as lower arm length increases (across the valid range)', () => {
     const lengths = [LOWER_ARM_LENGTH.min, 40, 42.5, 45, 47.5, 50, 55, LOWER_ARM_LENGTH.max]
-    const cambers = lengths.map(l => computeGeometry({ lowerArmLength: l }).rear.camberDeg)
+    const cambers = lengths.map(l => computeGeometry({ ...DEFAULTS, lowerArmLength: l }).rear.camberDeg)
     for (let i = 1; i < cambers.length; i++) {
       expect(cambers[i]).toBeLessThan(cambers[i - 1])
     }
@@ -33,13 +39,13 @@ describe('computeGeometry — camber', () => {
 
 describe('computeGeometry — outboard kingpin ball position', () => {
   it('places the lower outboard ball at lowerArmLength from the inboard pivot (horizontal arm)', () => {
-    const geo = computeGeometry({ lowerArmLength: 45 })
+    const geo = computeGeometry({ ...DEFAULTS, lowerArmLength: 45 })
     expect(geo.rear.lowerOutboard.x).toBeCloseTo(CHASSIS_BASELINE.blockLowerInboardX + 45, 5)
     expect(geo.rear.lowerOutboard.y).toBeCloseTo(CHASSIS_BASELINE.blockLowerY, 5)
   })
 
   it('places the upper outboard ball such that knuckle length and upper arm length are both satisfied', () => {
-    const geo = computeGeometry({ lowerArmLength: 50 })
+    const geo = computeGeometry({ ...DEFAULTS, lowerArmLength: 50 })
     const dKnuckle = Math.hypot(
       geo.rear.upperOutboard.x - geo.rear.lowerOutboard.x,
       geo.rear.upperOutboard.y - geo.rear.lowerOutboard.y,
@@ -54,32 +60,114 @@ describe('computeGeometry — outboard kingpin ball position', () => {
 })
 
 describe('computeGeometry — top view', () => {
-  it('places top-view points at y = 0 (forward axis is zero in the v1 slice)', () => {
-    const geo = computeGeometry({ lowerArmLength: 45 })
+  it('places lower-arm and wheel top-view points at y = 0 (forward axis is zero in the v1 slice)', () => {
+    const geo = computeGeometry({ ...DEFAULTS })
     expect(geo.top.lowerInboard.y).toBe(0)
     expect(geo.top.lowerOutboard.y).toBe(0)
     expect(geo.top.wheelCenter.y).toBe(0)
   })
 
   it('mirrors the rear-view x positions onto the top view', () => {
-    const geo = computeGeometry({ lowerArmLength: 50 })
+    const geo = computeGeometry({ ...DEFAULTS, lowerArmLength: 50 })
     expect(geo.top.lowerOutboard.x).toBeCloseTo(geo.rear.lowerOutboard.x, 5)
     expect(geo.top.wheelCenter.x).toBeCloseTo(geo.rear.wheelCenter.x, 5)
   })
 })
 
+describe('computeGeometry — toe', () => {
+  it('returns zero toe at the default tie rod length and lower arm length', () => {
+    const geo = computeGeometry({ ...DEFAULTS })
+    expect(geo.top.toeDegRight).toBeCloseTo(0, 5)
+    expect(geo.top.toeDegLeft).toBeCloseTo(0, 5)
+  })
+
+  it('places rack ball and tie rod outboard at the configured chassis positions when tie rod is at default', () => {
+    const geo = computeGeometry({ ...DEFAULTS })
+    expect(geo.top.rackBall.x).toBeCloseTo(CHASSIS_BASELINE.rackBallX, 5)
+    expect(geo.top.rackBall.y).toBeCloseTo(CHASSIS_BASELINE.rackBallY, 5)
+    // At zero toe the tie rod outboard sits at the kingpin + offset baseline.
+    expect(geo.top.tieRodOutboard.x).toBeCloseTo(geo.top.wheelCenter.x + CHASSIS_BASELINE.knuckleTieRodOffsetX, 5)
+    expect(geo.top.tieRodOutboard.y).toBeCloseTo(CHASSIS_BASELINE.knuckleTieRodOffsetY, 5)
+  })
+
+  it('keeps the tie rod outboard on a circle of constant radius around the kingpin as length changes', () => {
+    const baselineRadius = Math.hypot(
+      CHASSIS_BASELINE.knuckleTieRodOffsetX,
+      CHASSIS_BASELINE.knuckleTieRodOffsetY,
+    )
+    for (const l of [TIE_ROD_LENGTH.min, 35, 38, 42, 45, TIE_ROD_LENGTH.max]) {
+      const geo = computeGeometry({ ...DEFAULTS, tieRodLength: l })
+      const r = Math.hypot(
+        geo.top.tieRodOutboard.x - geo.top.wheelCenter.x,
+        geo.top.tieRodOutboard.y - geo.top.wheelCenter.y,
+      )
+      expect(r).toBeCloseTo(baselineRadius, 4)
+    }
+  })
+
+  it('produces equal left and right toe under mirror-symmetric setup (no steering input yet)', () => {
+    for (const l of [TIE_ROD_LENGTH.min, 35, 38, 42, 45, TIE_ROD_LENGTH.max]) {
+      const geo = computeGeometry({ ...DEFAULTS, tieRodLength: l })
+      expect(geo.top.toeDegLeft).toBeCloseTo(geo.top.toeDegRight, 10)
+    }
+  })
+
+  it('reverses toe direction when the tie rod is lengthened vs. shortened around the baseline', () => {
+    const longer = computeGeometry({ ...DEFAULTS, tieRodLength: TIE_ROD_LENGTH.defaultValue + 2 })
+    const shorter = computeGeometry({ ...DEFAULTS, tieRodLength: TIE_ROD_LENGTH.defaultValue - 2 })
+    expect(Math.sign(longer.top.toeDegRight)).not.toBe(Math.sign(shorter.top.toeDegRight))
+    expect(Math.abs(longer.top.toeDegRight)).toBeGreaterThan(0.1)
+    expect(Math.abs(shorter.top.toeDegRight)).toBeGreaterThan(0.1)
+  })
+
+  it('handles a vertical tie rod (parallel to chassis centerline) as a finite, zero-toe baseline', () => {
+    // Synthetic chassis: rack ball directly behind the knuckle attach baseline,
+    // so the tie rod runs purely along y at zero toe. This exercises the math
+    // at the geometric configuration where tie rod is parallel to the chassis
+    // forward axis — a known-singular direction for bump-steer (lands in #85)
+    // but a perfectly well-defined static toe input.
+    const verticalChassis: ChassisBaseline = {
+      ...CHASSIS_BASELINE,
+      rackBallX: 60,
+      rackBallY: -25,
+      knuckleTieRodOffsetX: -10,
+      knuckleTieRodOffsetY: -5,
+    }
+    // With default lowerArm=45 the kingpin sits at top-view (70, 0), so the
+    // baseline knuckle attach is (60, -5) and the rack ball is (60, -25).
+    // Distance = 20 → tie rod length 20 yields zero toe along a vertical link.
+    const geo = computeGeometry({ ...DEFAULTS, tieRodLength: 20 }, verticalChassis)
+    expect(geo.top.toeDegRight).toBeCloseTo(0, 5)
+    expect(Number.isFinite(geo.top.toeDegRight)).toBe(true)
+
+    // A perturbation away from the vertical baseline still produces finite toe.
+    const perturbed = computeGeometry({ ...DEFAULTS, tieRodLength: 19 }, verticalChassis)
+    expect(Number.isFinite(perturbed.top.toeDegRight)).toBe(true)
+    expect(Math.abs(perturbed.top.toeDegRight)).toBeGreaterThan(0)
+  })
+})
+
 describe('computeGeometry — robustness', () => {
   it('does not throw at the slider range extremes', () => {
-    expect(() => computeGeometry({ lowerArmLength: LOWER_ARM_LENGTH.min })).not.toThrow()
-    expect(() => computeGeometry({ lowerArmLength: LOWER_ARM_LENGTH.max })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, lowerArmLength: LOWER_ARM_LENGTH.min })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, lowerArmLength: LOWER_ARM_LENGTH.max })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, tieRodLength: TIE_ROD_LENGTH.min })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, tieRodLength: TIE_ROD_LENGTH.max })).not.toThrow()
   })
 
   it('returns finite numbers across the valid range', () => {
     for (let l = LOWER_ARM_LENGTH.min; l <= LOWER_ARM_LENGTH.max; l += 1) {
-      const geo = computeGeometry({ lowerArmLength: l })
+      const geo = computeGeometry({ ...DEFAULTS, lowerArmLength: l })
       expect(Number.isFinite(geo.rear.camberDeg)).toBe(true)
       expect(Number.isFinite(geo.rear.upperOutboard.x)).toBe(true)
       expect(Number.isFinite(geo.rear.upperOutboard.y)).toBe(true)
+    }
+    for (let l = TIE_ROD_LENGTH.min; l <= TIE_ROD_LENGTH.max; l += 0.5) {
+      const geo = computeGeometry({ ...DEFAULTS, tieRodLength: l })
+      expect(Number.isFinite(geo.top.toeDegRight)).toBe(true)
+      expect(Number.isFinite(geo.top.toeDegLeft)).toBe(true)
+      expect(Number.isFinite(geo.top.tieRodOutboard.x)).toBe(true)
+      expect(Number.isFinite(geo.top.tieRodOutboard.y)).toBe(true)
     }
   })
 })

--- a/lib/suspension/model.ts
+++ b/lib/suspension/model.ts
@@ -9,6 +9,7 @@ export type Point = { x: number; y: number }
 
 export type Setup = {
   lowerArmLength: number
+  tieRodLength: number
 }
 
 export type RearGeometry = {
@@ -21,10 +22,18 @@ export type RearGeometry = {
 }
 
 export type TopGeometry = {
-  // Top-view positions of the lower arm endpoints, projected (forward axis = 0 in v1).
+  // Right-side positions in chassis-relative top-view coords (y = +forward).
+  // Renderers mirror across x = 0 for the left side.
   lowerInboard: Point
   lowerOutboard: Point
   wheelCenter: Point
+  rackBall: Point        // right-side rack ball
+  tieRodOutboard: Point  // right-side tie rod outboard attach (knuckle pickup)
+  // Toe per side, signed: positive = toe in (front of wheel toward chassis centerline).
+  // Equal under mirror-symmetric setup with no steering input; diverge once
+  // the steering state slider lands in #84.
+  toeDegRight: number
+  toeDegLeft: number
 }
 
 export type Geometry = {
@@ -102,14 +111,86 @@ function computeRearGeometry(setup: Setup, chassis: ChassisBaseline): RearGeomet
   return { lowerInboard, lowerOutboard, upperInboard, upperOutboard, wheelCenter, camberDeg }
 }
 
-function computeTopGeometry(rear: RearGeometry): TopGeometry {
-  // v1 top-view projection: lower arm runs purely laterally at the wheel's
-  // longitudinal position (y = 0). Forward sweep / steering-induced rotation
-  // lands in #80 (steering & toe).
+// Pick the circle-circle intersection closest to a reference point. Used for
+// tie rod geometry where, as length sweeps through baseline, we need the
+// solution that varies continuously with the input rather than flipping to
+// the mirror.
+function intersectClosestToBaseline(
+  c1: Point,
+  r1: number,
+  c2: Point,
+  r2: number,
+  baseline: Point,
+): Point {
+  const dx = c2.x - c1.x
+  const dy = c2.y - c1.y
+  const d = Math.hypot(dx, dy)
+  if (d === 0 || d > r1 + r2 || d < Math.abs(r1 - r2)) {
+    // Out of reach: project the baseline onto c1's circle. Proper
+    // GeometryError for unreachable tie rod lengths lands in #86.
+    const bx = baseline.x - c1.x
+    const by = baseline.y - c1.y
+    const bd = Math.hypot(bx, by)
+    if (bd === 0) return { x: c1.x + r1, y: c1.y }
+    return { x: c1.x + (r1 * bx) / bd, y: c1.y + (r1 * by) / bd }
+  }
+  const a = (r1 * r1 - r2 * r2 + d * d) / (2 * d)
+  const h = Math.sqrt(Math.max(0, r1 * r1 - a * a))
+  const mx = c1.x + (a * dx) / d
+  const my = c1.y + (a * dy) / d
+  const ox = (h * dy) / d
+  const oy = (h * dx) / d
+  const p1 = { x: mx + ox, y: my - oy }
+  const p2 = { x: mx - ox, y: my + oy }
+  const d1 = Math.hypot(p1.x - baseline.x, p1.y - baseline.y)
+  const d2 = Math.hypot(p2.x - baseline.x, p2.y - baseline.y)
+  return d1 <= d2 ? p1 : p2
+}
+
+function computeTopGeometry(
+  setup: Setup,
+  rear: RearGeometry,
+  chassis: ChassisBaseline,
+): TopGeometry {
+  // v1 top-view collapse: kingpin axis projects to a single point at the
+  // wheel center's lateral position. Forward sweep of the lower arm lands
+  // alongside steering state in #84.
+  const kingpin: Point = { x: rear.wheelCenter.x, y: 0 }
+  const baselineAttach: Point = {
+    x: kingpin.x + chassis.knuckleTieRodOffsetX,
+    y: kingpin.y + chassis.knuckleTieRodOffsetY,
+  }
+  const rackBall: Point = { x: chassis.rackBallX, y: chassis.rackBallY }
+  const knuckleRadius = Math.hypot(
+    baselineAttach.x - kingpin.x,
+    baselineAttach.y - kingpin.y,
+  )
+
+  const tieRodOutboard = intersectClosestToBaseline(
+    kingpin,
+    knuckleRadius,
+    rackBall,
+    setup.tieRodLength,
+    baselineAttach,
+  )
+
+  // Toe = signed knuckle rotation from baseline. CCW (from above) on the
+  // right side = front of wheel toward centerline = toe in = positive.
+  const baselineAngle = Math.atan2(baselineAttach.y - kingpin.y, baselineAttach.x - kingpin.x)
+  const currentAngle = Math.atan2(tieRodOutboard.y - kingpin.y, tieRodOutboard.x - kingpin.x)
+  let rotationRad = currentAngle - baselineAngle
+  if (rotationRad > Math.PI) rotationRad -= 2 * Math.PI
+  if (rotationRad <= -Math.PI) rotationRad += 2 * Math.PI
+  const toeDegRight = rotationRad * (180 / Math.PI)
+
   return {
     lowerInboard: { x: rear.lowerInboard.x, y: 0 },
     lowerOutboard: { x: rear.lowerOutboard.x, y: 0 },
     wheelCenter: { x: rear.wheelCenter.x, y: 0 },
+    rackBall,
+    tieRodOutboard,
+    toeDegRight,
+    toeDegLeft: toeDegRight,
   }
 }
 
@@ -118,6 +199,6 @@ export function computeGeometry(
   chassis: ChassisBaseline = CHASSIS_BASELINE,
 ): Geometry {
   const rear = computeRearGeometry(setup, chassis)
-  const top = computeTopGeometry(rear)
+  const top = computeTopGeometry(setup, rear, chassis)
   return { rear, top, chassis }
 }


### PR DESCRIPTION
## Summary

- Renders the steering rack and tie rods on the top view in brand red (`#FF0020`, 2px), with pivot dots at each rack ball and tie rod outboard attach
- Adds a mirror-symmetric **Tie Rod Length** slider to the Setup panel (30–50 mm, 0.5 mm step, default 40)
- Adds **Toe (L) / Toe (R)** readouts to the Alignment panel — right-aligned monospace, 0.1° precision, equal under symmetric setup until steering state lands in #84

## Implementation notes

`computeGeometry` is extended with top-view steering math: the tie rod outboard attach is solved as the circle–circle intersection of the knuckle radius (around the kingpin) and the tie rod length (around the rack ball). The two solutions get disambiguated by picking the one closer to the baseline attach, so the result varies continuously through the default tie rod length rather than flipping to the mirror solution. Toe is the signed knuckle rotation from baseline (positive = toe in).

The top-view SVG now wraps its content in a `scale(1, -1)` group so children use math coords directly (+y = forward), keeping the rack visually behind the front axle.

Closes #80.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (2 pre-existing image warnings unrelated)
- [x] `npx vitest run` — 85/85 passing (16 in `lib/suspension/model.test.ts`, including default-zero-toe, symmetry, length-direction reversal, vertical-tie-rod boundary, and finite-output sweeps)
- [x] Vercel preview: rack + tie rods render in red, toe readouts update on slider drag, both wheels rotate mirror-symmetrically, camber slice still behaves
- [x] Mobile (production build): touch drag tracks both sliders without HMR-WebSocket interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)