### PR TITLE
feat: suspension tool — caster, KPI & trail slice (#81)

### DIFF
--- a/components/suspension/ReadoutPanel.tsx
+++ b/components/suspension/ReadoutPanel.tsx
@@ -20,6 +20,18 @@ export default function ReadoutPanel({ geometry }: Props) {
         value={`${geometry.rear.camberDeg.toFixed(PRECISION.angleDeg)}°`}
       />
       <Readout
+        label="Caster"
+        value={`${geometry.casterDeg.toFixed(PRECISION.angleDeg)}°`}
+      />
+      <Readout
+        label="KPI"
+        value={`${geometry.rear.kpiDeg.toFixed(PRECISION.angleDeg)}°`}
+      />
+      <Readout
+        label="Trail"
+        value={`${geometry.trailMm.toFixed(PRECISION.lengthMm)} mm`}
+      />
+      <Readout
         label="Toe (L)"
         value={`${geometry.top.toeDegLeft.toFixed(PRECISION.angleDeg)}°`}
       />

--- a/components/suspension/RearView.tsx
+++ b/components/suspension/RearView.tsx
@@ -4,6 +4,7 @@ const VIEW_WIDTH = 320
 const VIEW_HEIGHT = 130
 const VIEW_X_MIN = -VIEW_WIDTH / 2
 const VIEW_Y_MIN = -110  // y-up math; ground at math y=0 lands near the bottom of the SVG
+const STEERING_RED = '#FF0020'
 
 type Props = {
   geometry: Geometry
@@ -79,6 +80,50 @@ export default function RearView({ geometry }: Props) {
           strokeLinecap="round"
         />
 
+        {/* Upper arms */}
+        <line
+          x1={right.upperInboard.x}
+          y1={right.upperInboard.y}
+          x2={right.upperOutboard.x}
+          y2={right.upperOutboard.y}
+          stroke="currentColor"
+          strokeOpacity="0.75"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1={left.upperInboard.x}
+          y1={left.upperInboard.y}
+          x2={left.upperOutboard.x}
+          y2={left.upperOutboard.y}
+          stroke="currentColor"
+          strokeOpacity="0.75"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+
+        {/* Kingpin axis — dashed brand red through the rear-view kingpin balls */}
+        <line
+          x1={right.lowerOutboard.x}
+          y1={right.lowerOutboard.y}
+          x2={right.upperOutboard.x}
+          y2={right.upperOutboard.y}
+          stroke={STEERING_RED}
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
+          strokeLinecap="round"
+        />
+        <line
+          x1={left.lowerOutboard.x}
+          y1={left.lowerOutboard.y}
+          x2={left.upperOutboard.x}
+          y2={left.upperOutboard.y}
+          stroke={STEERING_RED}
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
+          strokeLinecap="round"
+        />
+
         {/* Wheels (tire + rim) — rectangle leaning at the camber angle */}
         <Wheel
           centerX={right.wheelCenter.x}
@@ -102,8 +147,12 @@ export default function RearView({ geometry }: Props) {
         {/* Pivot dots */}
         <Pivot x={right.lowerInboard.x} y={right.lowerInboard.y} />
         <Pivot x={right.lowerOutboard.x} y={right.lowerOutboard.y} />
+        <Pivot x={right.upperInboard.x} y={right.upperInboard.y} />
+        <Pivot x={right.upperOutboard.x} y={right.upperOutboard.y} />
         <Pivot x={left.lowerInboard.x} y={left.lowerInboard.y} />
         <Pivot x={left.lowerOutboard.x} y={left.lowerOutboard.y} />
+        <Pivot x={left.upperInboard.x} y={left.upperInboard.y} />
+        <Pivot x={left.upperOutboard.x} y={left.upperOutboard.y} />
       </g>
     </svg>
   )
@@ -177,5 +226,6 @@ function mirrorRear(rear: Geometry['rear']): Geometry['rear'] {
     upperOutboard: { x: -rear.upperOutboard.x, y: rear.upperOutboard.y },
     wheelCenter: { x: -rear.wheelCenter.x, y: rear.wheelCenter.y },
     camberDeg: rear.camberDeg,
+    kpiDeg: rear.kpiDeg,
   }
 }

--- a/components/suspension/SetupPanel.tsx
+++ b/components/suspension/SetupPanel.tsx
@@ -1,10 +1,14 @@
-import { LOWER_ARM_LENGTH, TIE_ROD_LENGTH } from '@/lib/suspension/config'
+import { LOWER_ARM_LENGTH, TIE_ROD_LENGTH, CASTER_SPACER, UPPER_ARM_LENGTH } from '@/lib/suspension/config'
 
 type Props = {
   lowerArmLength: number
   onLowerArmLengthChange: (value: number) => void
   tieRodLength: number
   onTieRodLengthChange: (value: number) => void
+  casterSpacerDeg: number
+  onCasterSpacerChange: (value: number) => void
+  upperArmLength: number
+  onUpperArmLengthChange: (value: number) => void
 }
 
 export default function SetupPanel({
@@ -12,6 +16,10 @@ export default function SetupPanel({
   onLowerArmLengthChange,
   tieRodLength,
   onTieRodLengthChange,
+  casterSpacerDeg,
+  onCasterSpacerChange,
+  upperArmLength,
+  onUpperArmLengthChange,
 }: Props) {
   return (
     <div
@@ -40,6 +48,31 @@ export default function SetupPanel({
         step={TIE_ROD_LENGTH.step}
         display={v => `${v.toFixed(1)} mm`}
         onChange={onTieRodLengthChange}
+      />
+
+      <Slider
+        label="Caster Spacer"
+        value={casterSpacerDeg}
+        min={CASTER_SPACER.min}
+        max={CASTER_SPACER.max}
+        step={CASTER_SPACER.step}
+        display={v => `${v.toFixed(0)}°`}
+        onChange={onCasterSpacerChange}
+      />
+
+      {/* Chassis config — moves to a collapsible Advanced section in #89. */}
+      <p className="mb-3 mt-6 font-mono text-xs uppercase tracking-[0.2em]" style={{ color: 'var(--muted)' }}>
+        Chassis
+      </p>
+
+      <Slider
+        label="Upper Arm Length"
+        value={upperArmLength}
+        min={UPPER_ARM_LENGTH.min}
+        max={UPPER_ARM_LENGTH.max}
+        step={UPPER_ARM_LENGTH.step}
+        display={v => `${v.toFixed(1)} mm`}
+        onChange={onUpperArmLengthChange}
       />
     </div>
   )

--- a/components/suspension/SuspensionTool.tsx
+++ b/components/suspension/SuspensionTool.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { LOWER_ARM_LENGTH, TIE_ROD_LENGTH } from '@/lib/suspension/config'
+import {
+  LOWER_ARM_LENGTH,
+  TIE_ROD_LENGTH,
+  CASTER_SPACER,
+  UPPER_ARM_LENGTH,
+} from '@/lib/suspension/config'
 import { computeGeometry } from '@/lib/suspension/model'
 import RearView from './RearView'
 import TopView from './TopView'
@@ -12,10 +17,12 @@ import StatePanel from './StatePanel'
 export default function SuspensionTool() {
   const [lowerArmLength, setLowerArmLength] = useState(LOWER_ARM_LENGTH.defaultValue)
   const [tieRodLength, setTieRodLength] = useState(TIE_ROD_LENGTH.defaultValue)
+  const [casterSpacerDeg, setCasterSpacerDeg] = useState(CASTER_SPACER.defaultValue)
+  const [upperArmLength, setUpperArmLength] = useState(UPPER_ARM_LENGTH.defaultValue)
 
   const geometry = useMemo(
-    () => computeGeometry({ lowerArmLength, tieRodLength }),
-    [lowerArmLength, tieRodLength],
+    () => computeGeometry({ lowerArmLength, tieRodLength, casterSpacerDeg, upperArmLength }),
+    [lowerArmLength, tieRodLength, casterSpacerDeg, upperArmLength],
   )
 
   return (
@@ -32,6 +39,10 @@ export default function SuspensionTool() {
             onLowerArmLengthChange={setLowerArmLength}
             tieRodLength={tieRodLength}
             onTieRodLengthChange={setTieRodLength}
+            casterSpacerDeg={casterSpacerDeg}
+            onCasterSpacerChange={setCasterSpacerDeg}
+            upperArmLength={upperArmLength}
+            onUpperArmLengthChange={setUpperArmLength}
           />
 
           <div className="flex flex-1 flex-col gap-4">

--- a/components/suspension/TopView.tsx
+++ b/components/suspension/TopView.tsx
@@ -17,6 +17,8 @@ export default function TopView({ geometry }: Props) {
   const right = {
     lowerInboard: top.lowerInboard,
     lowerOutboard: top.lowerOutboard,
+    upperInboard: top.upperInboard,
+    upperOutboard: top.upperOutboard,
     wheelCenter: top.wheelCenter,
     rackBall: top.rackBall,
     tieRodOutboard: top.tieRodOutboard,
@@ -24,6 +26,8 @@ export default function TopView({ geometry }: Props) {
   const left = {
     lowerInboard: mirrorX(top.lowerInboard),
     lowerOutboard: mirrorX(top.lowerOutboard),
+    upperInboard: mirrorX(top.upperInboard),
+    upperOutboard: mirrorX(top.upperOutboard),
     wheelCenter: mirrorX(top.wheelCenter),
     rackBall: mirrorX(top.rackBall),
     tieRodOutboard: mirrorX(top.tieRodOutboard),
@@ -71,6 +75,50 @@ export default function TopView({ geometry }: Props) {
           stroke="currentColor"
           strokeOpacity="0.75"
           strokeWidth="2"
+          strokeLinecap="round"
+        />
+
+        {/* Upper arms (top-down projection — picks up fore/aft sweep from caster) */}
+        <line
+          x1={right.upperInboard.x}
+          y1={right.upperInboard.y}
+          x2={right.upperOutboard.x}
+          y2={right.upperOutboard.y}
+          stroke="currentColor"
+          strokeOpacity="0.75"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1={left.upperInboard.x}
+          y1={left.upperInboard.y}
+          x2={left.upperOutboard.x}
+          y2={left.upperOutboard.y}
+          stroke="currentColor"
+          strokeOpacity="0.75"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+
+        {/* Kingpin axis (top-view projection) — dashed brand red */}
+        <line
+          x1={right.lowerOutboard.x}
+          y1={right.lowerOutboard.y}
+          x2={right.upperOutboard.x}
+          y2={right.upperOutboard.y}
+          stroke={STEERING_RED}
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
+          strokeLinecap="round"
+        />
+        <line
+          x1={left.lowerOutboard.x}
+          y1={left.lowerOutboard.y}
+          x2={left.upperOutboard.x}
+          y2={left.upperOutboard.y}
+          stroke={STEERING_RED}
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
           strokeLinecap="round"
         />
 
@@ -128,8 +176,12 @@ export default function TopView({ geometry }: Props) {
         {/* Pivot dots */}
         <Pivot x={right.lowerInboard.x} y={right.lowerInboard.y} />
         <Pivot x={right.lowerOutboard.x} y={right.lowerOutboard.y} />
+        <Pivot x={right.upperInboard.x} y={right.upperInboard.y} />
+        <Pivot x={right.upperOutboard.x} y={right.upperOutboard.y} />
         <Pivot x={left.lowerInboard.x} y={left.lowerInboard.y} />
         <Pivot x={left.lowerOutboard.x} y={left.lowerOutboard.y} />
+        <Pivot x={left.upperInboard.x} y={left.upperInboard.y} />
+        <Pivot x={left.upperOutboard.x} y={left.upperOutboard.y} />
         <Pivot x={right.rackBall.x} y={right.rackBall.y} />
         <Pivot x={left.rackBall.x} y={left.rackBall.y} />
         <Pivot x={right.tieRodOutboard.x} y={right.tieRodOutboard.y} />

--- a/lib/suspension/config.ts
+++ b/lib/suspension/config.ts
@@ -17,7 +17,6 @@ export type ChassisBaseline = {
   blockUpperInboardX: number
   blockUpperY: number
   knuckleLength: number       // distance between lower and upper kingpin balls along the carrier
-  upperArmLength: number      // chassis-fixed in v1 (the Advanced panel slider lands in #89)
   // Temporary placeholder pinning the 4-bar linkage's free DOF until the
   // Ride height slider (PRD Setup table) is wired up — at that point ride
   // height will determine the lower-arm angle and this field can be removed.
@@ -39,6 +38,11 @@ export type ChassisBaseline = {
 // Driver-tunable
 export const LOWER_ARM_LENGTH: SliderDef = { min: 35, max: 60, step: 0.5, defaultValue: 45 }
 export const TIE_ROD_LENGTH: SliderDef = { min: 30, max: 50, step: 0.5, defaultValue: 40 }
+export const CASTER_SPACER: SliderDef = { min: 0, max: 15, step: 1, defaultValue: 0 }
+
+// Chassis config — mirror-symmetric, persists per chassis. Inline in the
+// Setup panel for now; the dedicated Advanced collapse lands in #89.
+export const UPPER_ARM_LENGTH: SliderDef = { min: 35, max: 55, step: 0.5, defaultValue: 45 }
 
 // Chassis baseline. Engineered so that at default LOWER_ARM_LENGTH the kingpin is
 // vertical (camber = 0°) and the wheel sits with its bottom at ground.
@@ -48,7 +52,6 @@ export const CHASSIS_BASELINE: ChassisBaseline = {
   blockUpperInboardX: 25,        // TODO
   blockUpperY: 53,               // TODO
   knuckleLength: 45,             // TODO
-  upperArmLength: 45,            // TODO
   staticLowerArmAngleDeg: 0,     // TODO — currently horizontal
   tireOD: 60,                    // TODO
   tireWidth: 24,                 // TODO

--- a/lib/suspension/model.test.ts
+++ b/lib/suspension/model.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect } from 'vitest'
-import { computeGeometry } from './model'
-import { CHASSIS_BASELINE, LOWER_ARM_LENGTH, TIE_ROD_LENGTH } from './config'
+import { computeGeometry, computeTrail } from './model'
+import {
+  CHASSIS_BASELINE,
+  LOWER_ARM_LENGTH,
+  TIE_ROD_LENGTH,
+  UPPER_ARM_LENGTH,
+  CASTER_SPACER,
+} from './config'
 import type { ChassisBaseline } from './config'
 
 const DEFAULTS = {
   lowerArmLength: LOWER_ARM_LENGTH.defaultValue,
   tieRodLength: TIE_ROD_LENGTH.defaultValue,
+  upperArmLength: UPPER_ARM_LENGTH.defaultValue,
+  casterSpacerDeg: CASTER_SPACER.defaultValue,
 }
 
 describe('computeGeometry — camber', () => {
@@ -55,7 +63,7 @@ describe('computeGeometry — outboard kingpin ball position', () => {
       geo.rear.upperOutboard.y - geo.rear.upperInboard.y,
     )
     expect(dKnuckle).toBeCloseTo(CHASSIS_BASELINE.knuckleLength, 5)
-    expect(dUpperArm).toBeCloseTo(CHASSIS_BASELINE.upperArmLength, 5)
+    expect(dUpperArm).toBeCloseTo(UPPER_ARM_LENGTH.defaultValue, 5)
   })
 })
 
@@ -147,18 +155,116 @@ describe('computeGeometry — toe', () => {
   })
 })
 
+describe('computeGeometry — kingpin inclination (KPI)', () => {
+  it('returns zero KPI at the baseline lower arm length (kingpin vertical)', () => {
+    const geo = computeGeometry({ ...DEFAULTS })
+    expect(geo.rear.kpiDeg).toBeCloseTo(0, 5)
+  })
+
+  it('reports KPI as the negation of camber under the v1 zero-scrub assumption', () => {
+    for (const l of [40, 42.5, 45, 47.5, 50]) {
+      const geo = computeGeometry({ ...DEFAULTS, lowerArmLength: l })
+      expect(geo.rear.kpiDeg).toBeCloseTo(-geo.rear.camberDeg, 6)
+    }
+  })
+
+  it('returns positive KPI when the lower arm is lengthened (top of kingpin tilts inboard)', () => {
+    const geo = computeGeometry({ ...DEFAULTS, lowerArmLength: 50 })
+    expect(geo.rear.kpiDeg).toBeGreaterThan(0)
+    expect(geo.rear.kpiDeg).toBeCloseTo(6.38, 1)
+  })
+})
+
+describe('computeGeometry — caster', () => {
+  it('exposes caster equal to the caster spacer setting (1:1 in v1)', () => {
+    for (const c of [0, 1, 5, 10, 15]) {
+      const geo = computeGeometry({ ...DEFAULTS, casterSpacerDeg: c })
+      expect(geo.casterDeg).toBe(c)
+    }
+  })
+
+  it('shifts the entire upper hinge pin rearward by knuckleLength·tan(caster) — both ends move together', () => {
+    const c = 10
+    const geo = computeGeometry({ ...DEFAULTS, casterSpacerDeg: c })
+    const expected = -CHASSIS_BASELINE.knuckleLength * Math.tan((c * Math.PI) / 180)
+    expect(geo.top.upperInboard.y).toBeCloseTo(expected, 5)
+    expect(geo.top.upperOutboard.y).toBeCloseTo(expected, 5)
+    expect(geo.top.upperOutboard.y).toBeLessThan(0)
+  })
+
+  it('keeps the upper arm parallel to the lower arm (perpendicular to chassis centerline) at any caster', () => {
+    for (const c of [0, 5, 10, 15]) {
+      const geo = computeGeometry({ ...DEFAULTS, casterSpacerDeg: c })
+      expect(geo.top.upperOutboard.y).toBeCloseTo(geo.top.upperInboard.y, 9)
+      expect(geo.top.lowerOutboard.y).toBe(0)
+      expect(geo.top.lowerInboard.y).toBe(0)
+    }
+  })
+})
+
+describe('computeTrail — caster trail bridge', () => {
+  it('returns zero trail at zero caster regardless of tire size', () => {
+    expect(computeTrail(0, 0, 0, 60)).toBeCloseTo(0, 9)
+    expect(computeTrail(0, 5, 8, 60)).toBeCloseTo(0, 9)
+  })
+
+  it('returns R·tan(caster) for a positive caster angle', () => {
+    expect(computeTrail(5, 0, 0, 60)).toBeCloseTo(30 * Math.tan((5 * Math.PI) / 180), 6)
+    expect(computeTrail(10, 0, 0, 60)).toBeCloseTo(30 * Math.tan((10 * Math.PI) / 180), 6)
+  })
+
+  it('is symmetric about zero caster (negative caster → negative trail)', () => {
+    expect(computeTrail(-5, 0, 0, 60)).toBeCloseTo(-computeTrail(5, 0, 0, 60), 9)
+  })
+
+  it('scales linearly with tire OD', () => {
+    const small = computeTrail(8, 0, 0, 50)
+    const large = computeTrail(8, 0, 0, 100)
+    expect(large / small).toBeCloseTo(2, 6)
+  })
+
+  it('matches the trail readout exposed by computeGeometry at a known input', () => {
+    const geo = computeGeometry({ ...DEFAULTS, casterSpacerDeg: 7 })
+    expect(geo.trailMm).toBeCloseTo(computeTrail(7, geo.rear.kpiDeg, 0, CHASSIS_BASELINE.tireOD), 9)
+  })
+})
+
+describe('computeGeometry — upper arm', () => {
+  it('places upper outboard on a circle of radius UPPER_ARM_LENGTH around the upper inboard pivot', () => {
+    for (const u of [UPPER_ARM_LENGTH.min, 40, UPPER_ARM_LENGTH.defaultValue, 50, UPPER_ARM_LENGTH.max]) {
+      const geo = computeGeometry({ ...DEFAULTS, upperArmLength: u })
+      const r = Math.hypot(
+        geo.rear.upperOutboard.x - geo.rear.upperInboard.x,
+        geo.rear.upperOutboard.y - geo.rear.upperInboard.y,
+      )
+      expect(r).toBeCloseTo(u, 5)
+    }
+  })
+
+  it('changing upper arm length moves the kingpin angle (camber/KPI not held constant)', () => {
+    const shortArm = computeGeometry({ ...DEFAULTS, upperArmLength: 40 })
+    const longArm = computeGeometry({ ...DEFAULTS, upperArmLength: 50 })
+    expect(shortArm.rear.camberDeg).not.toBeCloseTo(longArm.rear.camberDeg, 1)
+  })
+})
+
 describe('computeGeometry — robustness', () => {
   it('does not throw at the slider range extremes', () => {
     expect(() => computeGeometry({ ...DEFAULTS, lowerArmLength: LOWER_ARM_LENGTH.min })).not.toThrow()
     expect(() => computeGeometry({ ...DEFAULTS, lowerArmLength: LOWER_ARM_LENGTH.max })).not.toThrow()
     expect(() => computeGeometry({ ...DEFAULTS, tieRodLength: TIE_ROD_LENGTH.min })).not.toThrow()
     expect(() => computeGeometry({ ...DEFAULTS, tieRodLength: TIE_ROD_LENGTH.max })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, upperArmLength: UPPER_ARM_LENGTH.min })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, upperArmLength: UPPER_ARM_LENGTH.max })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, casterSpacerDeg: CASTER_SPACER.min })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, casterSpacerDeg: CASTER_SPACER.max })).not.toThrow()
   })
 
   it('returns finite numbers across the valid range', () => {
     for (let l = LOWER_ARM_LENGTH.min; l <= LOWER_ARM_LENGTH.max; l += 1) {
       const geo = computeGeometry({ ...DEFAULTS, lowerArmLength: l })
       expect(Number.isFinite(geo.rear.camberDeg)).toBe(true)
+      expect(Number.isFinite(geo.rear.kpiDeg)).toBe(true)
       expect(Number.isFinite(geo.rear.upperOutboard.x)).toBe(true)
       expect(Number.isFinite(geo.rear.upperOutboard.y)).toBe(true)
     }
@@ -168,6 +274,12 @@ describe('computeGeometry — robustness', () => {
       expect(Number.isFinite(geo.top.toeDegLeft)).toBe(true)
       expect(Number.isFinite(geo.top.tieRodOutboard.x)).toBe(true)
       expect(Number.isFinite(geo.top.tieRodOutboard.y)).toBe(true)
+    }
+    for (let c = CASTER_SPACER.min; c <= CASTER_SPACER.max; c += 1) {
+      const geo = computeGeometry({ ...DEFAULTS, casterSpacerDeg: c })
+      expect(Number.isFinite(geo.casterDeg)).toBe(true)
+      expect(Number.isFinite(geo.trailMm)).toBe(true)
+      expect(Number.isFinite(geo.top.upperOutboard.y)).toBe(true)
     }
   })
 })

--- a/lib/suspension/model.ts
+++ b/lib/suspension/model.ts
@@ -10,6 +10,8 @@ export type Point = { x: number; y: number }
 export type Setup = {
   lowerArmLength: number
   tieRodLength: number
+  upperArmLength: number     // chassis config in PRD; same data layer as setup in v1
+  casterSpacerDeg: number    // 0–15° spacer stack on upper hinge pin; sets caster directly in v1
 }
 
 export type RearGeometry = {
@@ -19,6 +21,7 @@ export type RearGeometry = {
   upperOutboard: Point
   wheelCenter: Point
   camberDeg: number  // signed: positive = wheel top tilts outboard, negative = top tilts inboard
+  kpiDeg: number     // signed: positive = kingpin top tilts inboard (standard convention)
 }
 
 export type TopGeometry = {
@@ -26,6 +29,8 @@ export type TopGeometry = {
   // Renderers mirror across x = 0 for the left side.
   lowerInboard: Point
   lowerOutboard: Point
+  upperInboard: Point   // upper arm hinge pivot, top-view projection
+  upperOutboard: Point  // upper kingpin ball, top-view projection (offset fore/aft by caster)
   wheelCenter: Point
   rackBall: Point        // right-side rack ball
   tieRodOutboard: Point  // right-side tie rod outboard attach (knuckle pickup)
@@ -40,6 +45,8 @@ export type Geometry = {
   rear: RearGeometry
   top: TopGeometry
   chassis: ChassisBaseline  // exposed so renderers can size wheels, rims, etc.
+  casterDeg: number          // side-plane kingpin tilt; v1 = casterSpacerDeg
+  trailMm: number            // caster trail at the tire contact patch
 }
 
 // Intersect two circles in 2D. Returns the intersection point on the side
@@ -89,7 +96,7 @@ function computeRearGeometry(setup: Setup, chassis: ChassisBaseline): RearGeomet
 
   const upperOutboard = circleCircleIntersect(
     upperInboard,
-    chassis.upperArmLength,
+    setup.upperArmLength,
     lowerOutboard,
     chassis.knuckleLength,
     'outboard',
@@ -100,6 +107,11 @@ function computeRearGeometry(setup: Setup, chassis: ChassisBaseline): RearGeomet
   // atan2(dx, dy): zero when kingpin is vertical (dx=0, dy>0).
   // Negative when upper ball is inboard of lower ball (top of wheel tilts in → negative camber by RC convention).
   const camberDeg = Math.atan2(dx, dy) * (180 / Math.PI)
+  // KPI is the same physical kingpin angle but takes the opposite sign by
+  // convention (positive = top inboard). With zero scrub radius in v1 the
+  // wheel plane is co-planar with the kingpin axis, so KPI = -camber. They
+  // become independent once the scrub-radius slice (#82) decouples them.
+  const kpiDeg = -camberDeg
 
   // Wheel center sits on the kingpin axis at the midpoint between the two balls in v1.
   // Scrub-radius offset (lateral wheel offset from kingpin) lands in #82.
@@ -108,7 +120,7 @@ function computeRearGeometry(setup: Setup, chassis: ChassisBaseline): RearGeomet
     y: (lowerOutboard.y + upperOutboard.y) / 2,
   }
 
-  return { lowerInboard, lowerOutboard, upperInboard, upperOutboard, wheelCenter, camberDeg }
+  return { lowerInboard, lowerOutboard, upperInboard, upperOutboard, wheelCenter, camberDeg, kpiDeg }
 }
 
 // Pick the circle-circle intersection closest to a reference point. Used for
@@ -183,9 +195,22 @@ function computeTopGeometry(
   if (rotationRad <= -Math.PI) rotationRad += 2 * Math.PI
   const toeDegRight = rotationRad * (180 / Math.PI)
 
+  // Caster spacers shift the entire upper hinge pin fore/aft on the chassis,
+  // so both ends of the upper arm translate together and the arm stays
+  // parallel to the lower arm (perpendicular to the chassis centerline).
+  // Positive caster (standard convention) tilts the top of the kingpin axis
+  // rearward, so the upper arm sits at negative y (behind the lower arm) in
+  // top-view. Result: lower arm at y = 0; upper arm at y = -knuckle·tan(caster).
+  const casterRad = (setup.casterSpacerDeg * Math.PI) / 180
+  const upperHingeForeAft = -chassis.knuckleLength * Math.tan(casterRad)
+  const upperOutboard: Point = { x: rear.upperOutboard.x, y: upperHingeForeAft }
+  const upperInboard: Point = { x: rear.upperInboard.x, y: upperHingeForeAft }
+
   return {
     lowerInboard: { x: rear.lowerInboard.x, y: 0 },
     lowerOutboard: { x: rear.lowerOutboard.x, y: 0 },
+    upperInboard,
+    upperOutboard,
     wheelCenter: { x: rear.wheelCenter.x, y: 0 },
     rackBall,
     tieRodOutboard,
@@ -194,11 +219,27 @@ function computeTopGeometry(
   }
 }
 
+// Caster trail at the tire contact patch. The full PRD signature carries KPI
+// and wheel offset, both of which contribute once scrub radius decouples the
+// wheel plane from the kingpin axis (#82). In v1 those terms are absorbed by
+// the zero-scrub assumption and the simple R·tan(caster) formula holds.
+export function computeTrail(
+  casterDeg: number,
+  _kpiDeg: number,
+  _wheelOffsetMm: number,
+  tireOD: number,
+): number {
+  const casterRad = (casterDeg * Math.PI) / 180
+  return (tireOD / 2) * Math.tan(casterRad)
+}
+
 export function computeGeometry(
   setup: Setup,
   chassis: ChassisBaseline = CHASSIS_BASELINE,
 ): Geometry {
   const rear = computeRearGeometry(setup, chassis)
   const top = computeTopGeometry(setup, rear, chassis)
-  return { rear, top, chassis }
+  const casterDeg = setup.casterSpacerDeg
+  const trailMm = computeTrail(casterDeg, rear.kpiDeg, 0, chassis.tireOD)
+  return { rear, top, chassis, casterDeg, trailMm }
 }


### PR DESCRIPTION
## Summary

- Adds upper A-arms and the kingpin axis to both views; kingpin renders as a dashed `#FF0020` 1.5px line per the PRD color scheme
- New **Caster Spacer** slider (0–15°, 1° step, default 0) and **Upper Arm Length** slider (35–55 mm, default 45) under a "Chassis" subheader as a placeholder for the Advanced collapse coming in #89
- Caster, KPI, and Trail readouts in the Alignment panel (right-aligned monospace, 0.1° / 0.1 mm)
- Adds the `computeTrail` bridge function with the full PRD signature; v1 implementation uses R·tan(caster), with KPI/wheel-offset terms wiring in once scrub radius lands in #82

## Implementation notes

Caster spacers shift the entire upper hinge pin **rearward** on the chassis — both endpoints of the upper arm move together so the arm stays parallel to the lower arm and perpendicular to the chassis centerline. In top-view collapse the lower arm sits at y = 0 and the upper arm at y = -knuckleLength·tan(caster); the kingpin axis (lower outboard → upper outboard) picks up the side-plane tilt that defines the caster angle. Rear-plane geometry is unchanged by caster, which matches how the spacers physically work on RC drift cars.

`upperArmLength` moves out of `ChassisBaseline` into `Setup` since it is driver-tunable. KPI is exposed as the negation of camber under the v1 zero-scrub assumption; the two readouts will decouple in #82 when the wheel plane is offset from the kingpin axis.

Closes #81.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (2 pre-existing image warnings unrelated)
- [x] `npx vitest run` — 98/98 passing (29 in `lib/suspension/model.test.ts`, including KPI sign convention, caster 1:1 mapping, upper-hinge translation symmetry, parallel-upper-arm invariant, the `computeTrail` bridge at zero/positive/negative inputs and across tire OD)
- [x] Vercel preview: upper arms + dashed red kingpin in both views; caster slides upper arm rearward as a unit; caster/KPI/trail readouts respond correctly; lower-arm + tie-rod + camber + toe behavior unchanged
- [x] Mobile (production build): all four sliders track touch drags

🤖 Generated with [Claude Code](https://claude.com/claude-code)