### PR TITLE
feat: suspension tool — scrub radius slice (#82)

### DIFF
--- a/components/suspension/ReadoutPanel.tsx
+++ b/components/suspension/ReadoutPanel.tsx
@@ -32,6 +32,10 @@ export default function ReadoutPanel({ geometry }: Props) {
         value={`${geometry.trailMm.toFixed(PRECISION.lengthMm)} mm`}
       />
       <Readout
+        label="Scrub Radius"
+        value={`${geometry.scrubRadiusMm.toFixed(PRECISION.lengthMm)} mm`}
+      />
+      <Readout
         label="Toe (L)"
         value={`${geometry.top.toeDegLeft.toFixed(PRECISION.angleDeg)}°`}
       />

--- a/components/suspension/RearView.tsx
+++ b/components/suspension/RearView.tsx
@@ -11,7 +11,7 @@ type Props = {
 }
 
 export default function RearView({ geometry }: Props) {
-  const { rear, chassis } = geometry
+  const { rear, chassis, setup } = geometry
 
   // Right side as computed; left side is mirrored across the chassis centerline.
   const right = rear
@@ -129,7 +129,7 @@ export default function RearView({ geometry }: Props) {
           centerX={right.wheelCenter.x}
           centerY={right.wheelCenter.y}
           camberDeg={right.camberDeg}
-          tireOD={chassis.tireOD}
+          tireOD={setup.tireOD}
           tireWidth={chassis.tireWidth}
           rimDiameter={chassis.rimDiameter}
           rimWidth={chassis.rimWidth}
@@ -138,7 +138,7 @@ export default function RearView({ geometry }: Props) {
           centerX={left.wheelCenter.x}
           centerY={left.wheelCenter.y}
           camberDeg={left.camberDeg}
-          tireOD={chassis.tireOD}
+          tireOD={setup.tireOD}
           tireWidth={chassis.tireWidth}
           rimDiameter={chassis.rimDiameter}
           rimWidth={chassis.rimWidth}

--- a/components/suspension/SetupPanel.tsx
+++ b/components/suspension/SetupPanel.tsx
@@ -1,4 +1,12 @@
-import { LOWER_ARM_LENGTH, TIE_ROD_LENGTH, CASTER_SPACER, UPPER_ARM_LENGTH } from '@/lib/suspension/config'
+import {
+  LOWER_ARM_LENGTH,
+  TIE_ROD_LENGTH,
+  CASTER_SPACER,
+  UPPER_ARM_LENGTH,
+  WHEEL_HEX_THICKNESS,
+  WHEEL_OFFSET,
+  TIRE_OD,
+} from '@/lib/suspension/config'
 
 type Props = {
   lowerArmLength: number
@@ -7,8 +15,14 @@ type Props = {
   onTieRodLengthChange: (value: number) => void
   casterSpacerDeg: number
   onCasterSpacerChange: (value: number) => void
+  wheelHexThicknessMm: number
+  onWheelHexThicknessChange: (value: number) => void
+  wheelOffsetMm: number
+  onWheelOffsetChange: (value: number) => void
   upperArmLength: number
   onUpperArmLengthChange: (value: number) => void
+  tireOD: number
+  onTireODChange: (value: number) => void
 }
 
 export default function SetupPanel({
@@ -18,8 +32,14 @@ export default function SetupPanel({
   onTieRodLengthChange,
   casterSpacerDeg,
   onCasterSpacerChange,
+  wheelHexThicknessMm,
+  onWheelHexThicknessChange,
+  wheelOffsetMm,
+  onWheelOffsetChange,
   upperArmLength,
   onUpperArmLengthChange,
+  tireOD,
+  onTireODChange,
 }: Props) {
   return (
     <div
@@ -60,6 +80,26 @@ export default function SetupPanel({
         onChange={onCasterSpacerChange}
       />
 
+      <Slider
+        label="Wheel Hex Thickness"
+        value={wheelHexThicknessMm}
+        min={WHEEL_HEX_THICKNESS.min}
+        max={WHEEL_HEX_THICKNESS.max}
+        step={WHEEL_HEX_THICKNESS.step}
+        display={v => `${v.toFixed(0)} mm`}
+        onChange={onWheelHexThicknessChange}
+      />
+
+      <Slider
+        label="Wheel Offset"
+        value={wheelOffsetMm}
+        min={WHEEL_OFFSET.min}
+        max={WHEEL_OFFSET.max}
+        step={WHEEL_OFFSET.step}
+        display={v => `${v.toFixed(1)} mm`}
+        onChange={onWheelOffsetChange}
+      />
+
       {/* Chassis config — moves to a collapsible Advanced section in #89. */}
       <p className="mb-3 mt-6 font-mono text-xs uppercase tracking-[0.2em]" style={{ color: 'var(--muted)' }}>
         Chassis
@@ -73,6 +113,16 @@ export default function SetupPanel({
         step={UPPER_ARM_LENGTH.step}
         display={v => `${v.toFixed(1)} mm`}
         onChange={onUpperArmLengthChange}
+      />
+
+      <Slider
+        label="Tire OD"
+        value={tireOD}
+        min={TIRE_OD.min}
+        max={TIRE_OD.max}
+        step={TIRE_OD.step}
+        display={v => `${v.toFixed(1)} mm`}
+        onChange={onTireODChange}
       />
     </div>
   )

--- a/components/suspension/SuspensionTool.tsx
+++ b/components/suspension/SuspensionTool.tsx
@@ -6,6 +6,9 @@ import {
   TIE_ROD_LENGTH,
   CASTER_SPACER,
   UPPER_ARM_LENGTH,
+  WHEEL_HEX_THICKNESS,
+  WHEEL_OFFSET,
+  TIRE_OD,
 } from '@/lib/suspension/config'
 import { computeGeometry } from '@/lib/suspension/model'
 import RearView from './RearView'
@@ -19,10 +22,22 @@ export default function SuspensionTool() {
   const [tieRodLength, setTieRodLength] = useState(TIE_ROD_LENGTH.defaultValue)
   const [casterSpacerDeg, setCasterSpacerDeg] = useState(CASTER_SPACER.defaultValue)
   const [upperArmLength, setUpperArmLength] = useState(UPPER_ARM_LENGTH.defaultValue)
+  const [wheelHexThicknessMm, setWheelHexThicknessMm] = useState(WHEEL_HEX_THICKNESS.defaultValue)
+  const [wheelOffsetMm, setWheelOffsetMm] = useState(WHEEL_OFFSET.defaultValue)
+  const [tireOD, setTireOD] = useState(TIRE_OD.defaultValue)
 
   const geometry = useMemo(
-    () => computeGeometry({ lowerArmLength, tieRodLength, casterSpacerDeg, upperArmLength }),
-    [lowerArmLength, tieRodLength, casterSpacerDeg, upperArmLength],
+    () =>
+      computeGeometry({
+        lowerArmLength,
+        tieRodLength,
+        casterSpacerDeg,
+        upperArmLength,
+        wheelHexThicknessMm,
+        wheelOffsetMm,
+        tireOD,
+      }),
+    [lowerArmLength, tieRodLength, casterSpacerDeg, upperArmLength, wheelHexThicknessMm, wheelOffsetMm, tireOD],
   )
 
   return (
@@ -41,8 +56,14 @@ export default function SuspensionTool() {
             onTieRodLengthChange={setTieRodLength}
             casterSpacerDeg={casterSpacerDeg}
             onCasterSpacerChange={setCasterSpacerDeg}
+            wheelHexThicknessMm={wheelHexThicknessMm}
+            onWheelHexThicknessChange={setWheelHexThicknessMm}
+            wheelOffsetMm={wheelOffsetMm}
+            onWheelOffsetChange={setWheelOffsetMm}
             upperArmLength={upperArmLength}
             onUpperArmLengthChange={setUpperArmLength}
+            tireOD={tireOD}
+            onTireODChange={setTireOD}
           />
 
           <div className="flex flex-1 flex-col gap-4">

--- a/components/suspension/TopView.tsx
+++ b/components/suspension/TopView.tsx
@@ -12,7 +12,7 @@ type Props = {
 const STEERING_RED = '#FF0020'
 
 export default function TopView({ geometry }: Props) {
-  const { top, chassis } = geometry
+  const { top, chassis, setup } = geometry
 
   const right = {
     lowerInboard: top.lowerInboard,
@@ -128,7 +128,7 @@ export default function TopView({ geometry }: Props) {
         <Wheel
           center={right.wheelCenter}
           tireWidth={chassis.tireWidth}
-          tireOD={chassis.tireOD}
+          tireOD={setup.tireOD}
           rimWidth={chassis.rimWidth}
           rimOD={chassis.rimDiameter}
           toeDeg={top.toeDegRight}
@@ -136,7 +136,7 @@ export default function TopView({ geometry }: Props) {
         <Wheel
           center={left.wheelCenter}
           tireWidth={chassis.tireWidth}
-          tireOD={chassis.tireOD}
+          tireOD={setup.tireOD}
           rimWidth={chassis.rimWidth}
           rimOD={chassis.rimDiameter}
           toeDeg={-top.toeDegLeft}

--- a/lib/suspension/config.ts
+++ b/lib/suspension/config.ts
@@ -21,8 +21,8 @@ export type ChassisBaseline = {
   // Ride height slider (PRD Setup table) is wired up — at that point ride
   // height will determine the lower-arm angle and this field can be removed.
   staticLowerArmAngleDeg: number
-  // Visualization-only baseline; these gain dedicated sliders in #82.
-  tireOD: number
+  // Visualization-only baseline. tireOD moved to Setup in #82; the remaining
+  // tire/rim dimensions are static chassis defaults until further refinement.
   tireWidth: number
   rimDiameter: number
   rimWidth: number
@@ -39,10 +39,13 @@ export type ChassisBaseline = {
 export const LOWER_ARM_LENGTH: SliderDef = { min: 35, max: 60, step: 0.5, defaultValue: 45 }
 export const TIE_ROD_LENGTH: SliderDef = { min: 30, max: 50, step: 0.5, defaultValue: 40 }
 export const CASTER_SPACER: SliderDef = { min: 0, max: 15, step: 1, defaultValue: 0 }
+export const WHEEL_HEX_THICKNESS: SliderDef = { min: 0, max: 10, step: 1, defaultValue: 5 }
+export const WHEEL_OFFSET: SliderDef = { min: -5, max: 15, step: 0.5, defaultValue: 0 }
 
 // Chassis config — mirror-symmetric, persists per chassis. Inline in the
 // Setup panel for now; the dedicated Advanced collapse lands in #89.
 export const UPPER_ARM_LENGTH: SliderDef = { min: 35, max: 55, step: 0.5, defaultValue: 45 }
+export const TIRE_OD: SliderDef = { min: 50, max: 70, step: 0.5, defaultValue: 60 }
 
 // Chassis baseline. Engineered so that at default LOWER_ARM_LENGTH the kingpin is
 // vertical (camber = 0°) and the wheel sits with its bottom at ground.
@@ -53,7 +56,6 @@ export const CHASSIS_BASELINE: ChassisBaseline = {
   blockUpperY: 53,               // TODO
   knuckleLength: 45,             // TODO
   staticLowerArmAngleDeg: 0,     // TODO — currently horizontal
-  tireOD: 60,                    // TODO
   tireWidth: 24,                 // TODO
   rimDiameter: 35,               // TODO
   rimWidth: 18,                  // TODO

--- a/lib/suspension/model.test.ts
+++ b/lib/suspension/model.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { computeGeometry, computeTrail } from './model'
+import { computeGeometry, computeTrail, computeScrubRadius } from './model'
 import {
   CHASSIS_BASELINE,
   LOWER_ARM_LENGTH,
   TIE_ROD_LENGTH,
   UPPER_ARM_LENGTH,
   CASTER_SPACER,
+  WHEEL_HEX_THICKNESS,
+  WHEEL_OFFSET,
+  TIRE_OD,
 } from './config'
 import type { ChassisBaseline } from './config'
 
@@ -14,6 +17,9 @@ const DEFAULTS = {
   tieRodLength: TIE_ROD_LENGTH.defaultValue,
   upperArmLength: UPPER_ARM_LENGTH.defaultValue,
   casterSpacerDeg: CASTER_SPACER.defaultValue,
+  wheelHexThicknessMm: WHEEL_HEX_THICKNESS.defaultValue,
+  wheelOffsetMm: WHEEL_OFFSET.defaultValue,
+  tireOD: TIRE_OD.defaultValue,
 }
 
 describe('computeGeometry — camber', () => {
@@ -91,10 +97,11 @@ describe('computeGeometry — toe', () => {
 
   it('places rack ball and tie rod outboard at the configured chassis positions when tie rod is at default', () => {
     const geo = computeGeometry({ ...DEFAULTS })
+    const kingpinX = (geo.rear.lowerOutboard.x + geo.rear.upperOutboard.x) / 2
     expect(geo.top.rackBall.x).toBeCloseTo(CHASSIS_BASELINE.rackBallX, 5)
     expect(geo.top.rackBall.y).toBeCloseTo(CHASSIS_BASELINE.rackBallY, 5)
-    // At zero toe the tie rod outboard sits at the kingpin + offset baseline.
-    expect(geo.top.tieRodOutboard.x).toBeCloseTo(geo.top.wheelCenter.x + CHASSIS_BASELINE.knuckleTieRodOffsetX, 5)
+    // At zero toe the tie rod outboard sits at the kingpin midpoint + offset baseline.
+    expect(geo.top.tieRodOutboard.x).toBeCloseTo(kingpinX + CHASSIS_BASELINE.knuckleTieRodOffsetX, 5)
     expect(geo.top.tieRodOutboard.y).toBeCloseTo(CHASSIS_BASELINE.knuckleTieRodOffsetY, 5)
   })
 
@@ -105,9 +112,10 @@ describe('computeGeometry — toe', () => {
     )
     for (const l of [TIE_ROD_LENGTH.min, 35, 38, 42, 45, TIE_ROD_LENGTH.max]) {
       const geo = computeGeometry({ ...DEFAULTS, tieRodLength: l })
+      const kingpinX = (geo.rear.lowerOutboard.x + geo.rear.upperOutboard.x) / 2
       const r = Math.hypot(
-        geo.top.tieRodOutboard.x - geo.top.wheelCenter.x,
-        geo.top.tieRodOutboard.y - geo.top.wheelCenter.y,
+        geo.top.tieRodOutboard.x - kingpinX,
+        geo.top.tieRodOutboard.y - 0,
       )
       expect(r).toBeCloseTo(baselineRadius, 4)
     }
@@ -225,7 +233,78 @@ describe('computeTrail — caster trail bridge', () => {
 
   it('matches the trail readout exposed by computeGeometry at a known input', () => {
     const geo = computeGeometry({ ...DEFAULTS, casterSpacerDeg: 7 })
-    expect(geo.trailMm).toBeCloseTo(computeTrail(7, geo.rear.kpiDeg, 0, CHASSIS_BASELINE.tireOD), 9)
+    expect(geo.trailMm).toBeCloseTo(computeTrail(7, geo.rear.kpiDeg, geo.setup.wheelOffsetMm, geo.setup.tireOD), 9)
+  })
+
+  it('responds linearly to tire OD when read off computeGeometry', () => {
+    const small = computeGeometry({ ...DEFAULTS, casterSpacerDeg: 8, tireOD: 50 })
+    const large = computeGeometry({ ...DEFAULTS, casterSpacerDeg: 8, tireOD: 70 })
+    expect(large.trailMm / small.trailMm).toBeCloseTo(70 / 50, 6)
+  })
+})
+
+describe('computeScrubRadius — bridge', () => {
+  it('returns zero when wheel offset and hex thickness are both zero (regardless of KPI/tire OD)', () => {
+    expect(computeScrubRadius(0, 0, 0, 60)).toBeCloseTo(0, 9)
+    expect(computeScrubRadius(0, 0, 5, 60)).not.toBeCloseTo(0, 1)
+    // The KPI term still applies — only (offset+hex)=0 *and* KPI=0 forces zero.
+    expect(computeScrubRadius(0, 0, 0, 80)).toBeCloseTo(0, 9)
+  })
+
+  it('equals (hex + offset) when KPI is zero (kingpin vertical)', () => {
+    expect(computeScrubRadius(0, 5, 0, 60)).toBeCloseTo(5, 9)
+    expect(computeScrubRadius(3, 5, 0, 60)).toBeCloseTo(8, 9)
+    expect(computeScrubRadius(-2, 5, 0, 60)).toBeCloseTo(3, 9)
+  })
+
+  it('returns negative scrub for zero offset and positive KPI (contact patch sits inboard of kingpin at ground)', () => {
+    const result = computeScrubRadius(0, 0, 5, 60)
+    expect(result).toBeCloseTo(-(60 / 2) * Math.tan((5 * Math.PI) / 180), 6)
+    expect(result).toBeLessThan(0)
+  })
+
+  it('matches the closed-form (hex+offset)/cos(KPI) − R·tan(KPI) at a combined input', () => {
+    const expected = 8 / Math.cos((5 * Math.PI) / 180) - 30 * Math.tan((5 * Math.PI) / 180)
+    expect(computeScrubRadius(3, 5, 5, 60)).toBeCloseTo(expected, 9)
+  })
+
+  it('flips sign when KPI flips sign (positive vs. negative kingpin tilt)', () => {
+    expect(computeScrubRadius(0, 0, 5, 60)).toBeCloseTo(-computeScrubRadius(0, 0, -5, 60), 9)
+  })
+
+  it('matches the scrub radius readout exposed by computeGeometry', () => {
+    const geo = computeGeometry({ ...DEFAULTS, wheelHexThicknessMm: 4, wheelOffsetMm: 2, lowerArmLength: 50 })
+    expect(geo.scrubRadiusMm).toBeCloseTo(
+      computeScrubRadius(2, 4, geo.rear.kpiDeg, geo.setup.tireOD),
+      9,
+    )
+  })
+})
+
+describe('computeGeometry — wheel offset and hex thickness', () => {
+  it('places the rear-view wheel center perpendicular-outboard of the kingpin midpoint by (hex + offset)', () => {
+    const geo = computeGeometry({ ...DEFAULTS, wheelHexThicknessMm: 5, wheelOffsetMm: 3 })
+    // At zero camber the perpendicular direction is pure +x, so the wheel
+    // center sits exactly (hex+offset) outboard of the kingpin midpoint.
+    const kingpinMidX = (geo.rear.lowerOutboard.x + geo.rear.upperOutboard.x) / 2
+    expect(geo.rear.wheelCenter.x - kingpinMidX).toBeCloseTo(8, 5)
+  })
+
+  it('shifts wheel center outboard by 1mm per mm of hex thickness or wheel offset (zero camber)', () => {
+    const baseline = computeGeometry({ ...DEFAULTS, wheelHexThicknessMm: 0, wheelOffsetMm: 0 })
+    const plusHex = computeGeometry({ ...DEFAULTS, wheelHexThicknessMm: 4, wheelOffsetMm: 0 })
+    const plusOffset = computeGeometry({ ...DEFAULTS, wheelHexThicknessMm: 0, wheelOffsetMm: 4 })
+    expect(plusHex.rear.wheelCenter.x - baseline.rear.wheelCenter.x).toBeCloseTo(4, 5)
+    expect(plusOffset.rear.wheelCenter.x - baseline.rear.wheelCenter.x).toBeCloseTo(4, 5)
+  })
+
+  it('does not change camber, KPI, or the kingpin ball positions', () => {
+    const a = computeGeometry({ ...DEFAULTS, lowerArmLength: 50, wheelHexThicknessMm: 0, wheelOffsetMm: 0 })
+    const b = computeGeometry({ ...DEFAULTS, lowerArmLength: 50, wheelHexThicknessMm: 8, wheelOffsetMm: 4 })
+    expect(b.rear.camberDeg).toBeCloseTo(a.rear.camberDeg, 9)
+    expect(b.rear.kpiDeg).toBeCloseTo(a.rear.kpiDeg, 9)
+    expect(b.rear.lowerOutboard.x).toBeCloseTo(a.rear.lowerOutboard.x, 9)
+    expect(b.rear.upperOutboard.x).toBeCloseTo(a.rear.upperOutboard.x, 9)
   })
 })
 
@@ -258,6 +337,12 @@ describe('computeGeometry — robustness', () => {
     expect(() => computeGeometry({ ...DEFAULTS, upperArmLength: UPPER_ARM_LENGTH.max })).not.toThrow()
     expect(() => computeGeometry({ ...DEFAULTS, casterSpacerDeg: CASTER_SPACER.min })).not.toThrow()
     expect(() => computeGeometry({ ...DEFAULTS, casterSpacerDeg: CASTER_SPACER.max })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, wheelHexThicknessMm: WHEEL_HEX_THICKNESS.min })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, wheelHexThicknessMm: WHEEL_HEX_THICKNESS.max })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, wheelOffsetMm: WHEEL_OFFSET.min })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, wheelOffsetMm: WHEEL_OFFSET.max })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, tireOD: TIRE_OD.min })).not.toThrow()
+    expect(() => computeGeometry({ ...DEFAULTS, tireOD: TIRE_OD.max })).not.toThrow()
   })
 
   it('returns finite numbers across the valid range', () => {
@@ -267,6 +352,7 @@ describe('computeGeometry — robustness', () => {
       expect(Number.isFinite(geo.rear.kpiDeg)).toBe(true)
       expect(Number.isFinite(geo.rear.upperOutboard.x)).toBe(true)
       expect(Number.isFinite(geo.rear.upperOutboard.y)).toBe(true)
+      expect(Number.isFinite(geo.scrubRadiusMm)).toBe(true)
     }
     for (let l = TIE_ROD_LENGTH.min; l <= TIE_ROD_LENGTH.max; l += 0.5) {
       const geo = computeGeometry({ ...DEFAULTS, tieRodLength: l })
@@ -280,6 +366,14 @@ describe('computeGeometry — robustness', () => {
       expect(Number.isFinite(geo.casterDeg)).toBe(true)
       expect(Number.isFinite(geo.trailMm)).toBe(true)
       expect(Number.isFinite(geo.top.upperOutboard.y)).toBe(true)
+    }
+    for (let h = WHEEL_HEX_THICKNESS.min; h <= WHEEL_HEX_THICKNESS.max; h += 1) {
+      for (let o = WHEEL_OFFSET.min; o <= WHEEL_OFFSET.max; o += 2) {
+        const geo = computeGeometry({ ...DEFAULTS, wheelHexThicknessMm: h, wheelOffsetMm: o })
+        expect(Number.isFinite(geo.scrubRadiusMm)).toBe(true)
+        expect(Number.isFinite(geo.rear.wheelCenter.x)).toBe(true)
+        expect(Number.isFinite(geo.rear.wheelCenter.y)).toBe(true)
+      }
     }
   })
 })

--- a/lib/suspension/model.ts
+++ b/lib/suspension/model.ts
@@ -10,8 +10,11 @@ export type Point = { x: number; y: number }
 export type Setup = {
   lowerArmLength: number
   tieRodLength: number
-  upperArmLength: number     // chassis config in PRD; same data layer as setup in v1
-  casterSpacerDeg: number    // 0–15° spacer stack on upper hinge pin; sets caster directly in v1
+  upperArmLength: number          // chassis config in PRD; same data layer as setup in v1
+  casterSpacerDeg: number         // 0–15° spacer stack on upper hinge pin; sets caster directly in v1
+  wheelHexThicknessMm: number     // hub spacer between carrier and rim; always positive
+  wheelOffsetMm: number           // rim's lateral offset from its mounting face; signed
+  tireOD: number                  // chassis config in PRD; surfaced inline until #89
 }
 
 export type RearGeometry = {
@@ -44,9 +47,11 @@ export type TopGeometry = {
 export type Geometry = {
   rear: RearGeometry
   top: TopGeometry
-  chassis: ChassisBaseline  // exposed so renderers can size wheels, rims, etc.
+  chassis: ChassisBaseline   // exposed so renderers can size wheels, rims, etc.
+  setup: Setup               // exposed so renderers can read tireOD, hex/offset, etc.
   casterDeg: number          // side-plane kingpin tilt; v1 = casterSpacerDeg
   trailMm: number            // caster trail at the tire contact patch
+  scrubRadiusMm: number      // signed: positive = wheel contact outboard of kingpin axis at ground
 }
 
 // Intersect two circles in 2D. Returns the intersection point on the side
@@ -108,16 +113,23 @@ function computeRearGeometry(setup: Setup, chassis: ChassisBaseline): RearGeomet
   // Negative when upper ball is inboard of lower ball (top of wheel tilts in → negative camber by RC convention).
   const camberDeg = Math.atan2(dx, dy) * (180 / Math.PI)
   // KPI is the same physical kingpin angle but takes the opposite sign by
-  // convention (positive = top inboard). With zero scrub radius in v1 the
-  // wheel plane is co-planar with the kingpin axis, so KPI = -camber. They
-  // become independent once the scrub-radius slice (#82) decouples them.
+  // convention (positive = top inboard). The wheel plane is parallel to the
+  // kingpin axis (the carrier is rigid), so KPI = -camber holds even after
+  // wheel offset displaces the wheel center off the kingpin axis.
   const kpiDeg = -camberDeg
 
-  // Wheel center sits on the kingpin axis at the midpoint between the two balls in v1.
-  // Scrub-radius offset (lateral wheel offset from kingpin) lands in #82.
-  const wheelCenter: Point = {
+  // Wheel center sits at perpendicular offset (hex + wheelOffset) from the
+  // kingpin axis, on the outboard side (right wheel). Perpendicular outboard
+  // in the rear plane = the kingpin direction rotated -90°: (cos(camber), -sin(camber)).
+  const camberRad = (camberDeg * Math.PI) / 180
+  const lateralOffset = setup.wheelHexThicknessMm + setup.wheelOffsetMm
+  const kingpinMidpoint: Point = {
     x: (lowerOutboard.x + upperOutboard.x) / 2,
     y: (lowerOutboard.y + upperOutboard.y) / 2,
+  }
+  const wheelCenter: Point = {
+    x: kingpinMidpoint.x + lateralOffset * Math.cos(camberRad),
+    y: kingpinMidpoint.y - lateralOffset * Math.sin(camberRad),
   }
 
   return { lowerInboard, lowerOutboard, upperInboard, upperOutboard, wheelCenter, camberDeg, kpiDeg }
@@ -164,10 +176,13 @@ function computeTopGeometry(
   rear: RearGeometry,
   chassis: ChassisBaseline,
 ): TopGeometry {
-  // v1 top-view collapse: kingpin axis projects to a single point at the
-  // wheel center's lateral position. Forward sweep of the lower arm lands
-  // alongside steering state in #84.
-  const kingpin: Point = { x: rear.wheelCenter.x, y: 0 }
+  // v1 top-view collapse: the kingpin axis projects to a single point at the
+  // midpoint of the two kingpin balls — distinct from the wheel center once
+  // wheel offset displaces the rim laterally (#82). The knuckle's tie rod
+  // attach is rigid with the kingpin axis, so its top-view radius and
+  // baseline angle are measured around this midpoint.
+  const kingpinMidX = (rear.lowerOutboard.x + rear.upperOutboard.x) / 2
+  const kingpin: Point = { x: kingpinMidX, y: 0 }
   const baselineAttach: Point = {
     x: kingpin.x + chassis.knuckleTieRodOffsetX,
     y: kingpin.y + chassis.knuckleTieRodOffsetY,
@@ -219,10 +234,10 @@ function computeTopGeometry(
   }
 }
 
-// Caster trail at the tire contact patch. The full PRD signature carries KPI
-// and wheel offset, both of which contribute once scrub radius decouples the
-// wheel plane from the kingpin axis (#82). In v1 those terms are absorbed by
-// the zero-scrub assumption and the simple R·tan(caster) formula holds.
+// Caster trail at the tire contact patch. v1 uses the standard mechanical
+// trail formula R·tan(caster); the KPI and wheel-offset terms enter the full
+// 3D coupling but are second-order for typical RC drift values and are left
+// for a future refinement.
 export function computeTrail(
   casterDeg: number,
   _kpiDeg: number,
@@ -233,6 +248,24 @@ export function computeTrail(
   return (tireOD / 2) * Math.tan(casterRad)
 }
 
+// Scrub radius — signed lateral distance from the kingpin axis (where it
+// meets the ground) to the tire contact center. Positive = contact patch
+// outboard of kingpin. Derivation: wheel center sits perpendicular to the
+// kingpin by (hex + offset); contact center sits directly below wheel center
+// at height tireOD/2; the kingpin's lateral position at ground is the wheel
+// center offset by (hex+offset)/cos(KPI) inboard plus (tireOD/2)·tan(KPI)
+// outboard, leaving scrub = (hex+offset)/cos(KPI) − (tireOD/2)·tan(KPI).
+export function computeScrubRadius(
+  wheelOffsetMm: number,
+  hexThicknessMm: number,
+  kpiDeg: number,
+  tireOD: number,
+): number {
+  const kpiRad = (kpiDeg * Math.PI) / 180
+  const lateral = wheelOffsetMm + hexThicknessMm
+  return lateral / Math.cos(kpiRad) - (tireOD / 2) * Math.tan(kpiRad)
+}
+
 export function computeGeometry(
   setup: Setup,
   chassis: ChassisBaseline = CHASSIS_BASELINE,
@@ -240,6 +273,12 @@ export function computeGeometry(
   const rear = computeRearGeometry(setup, chassis)
   const top = computeTopGeometry(setup, rear, chassis)
   const casterDeg = setup.casterSpacerDeg
-  const trailMm = computeTrail(casterDeg, rear.kpiDeg, 0, chassis.tireOD)
-  return { rear, top, chassis, casterDeg, trailMm }
+  const trailMm = computeTrail(casterDeg, rear.kpiDeg, setup.wheelOffsetMm, setup.tireOD)
+  const scrubRadiusMm = computeScrubRadius(
+    setup.wheelOffsetMm,
+    setup.wheelHexThicknessMm,
+    rear.kpiDeg,
+    setup.tireOD,
+  )
+  return { rear, top, chassis, setup, casterDeg, trailMm, scrubRadiusMm }
 }


### PR DESCRIPTION
## Summary

- New **Wheel Hex Thickness** (0–10 mm) and **Wheel Offset** (-5 to 15 mm) sliders in Setup; **Tire OD** (50–70 mm) under Chassis
- New **Scrub Radius** readout in the Alignment panel (0.1 mm precision)
- `computeScrubRadius` bridge function landed; `computeTrail` now passes `wheelOffset` through per the PRD signature
- `tireOD` moves out of `ChassisBaseline` into `Setup` (consistent with the upper-arm move from #81); `Geometry` now exposes `setup` so renderers can pull tire dimensions without prop-drilling

## Implementation notes

The wheel center now sits at perpendicular offset `(hex + offset)` from the kingpin midpoint in the rear plane. The closed-form scrub is `(hex + offset)/cos(KPI) − (tireOD/2)·tan(KPI)` — positive offset adds positive scrub, positive KPI tilts the kingpin outboard at ground and subtracts. Trail keeps its v1 `R·tan(caster)` formula; the wheel-offset/KPI coupling on trail is second-order for RC drift values and is parked for a later refinement.

The top-view collapse switches the kingpin's projected position from the wheel center to the kingpin midpoint, since wheel offset now decouples them. The tie rod outboard attach is rigid with the kingpin axis (not the rim), so its baseline radius is measured around the midpoint — preserving zero-toe at the default tie rod length regardless of hex/offset.

Closes #82.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (2 pre-existing image warnings unrelated)
- [x] `npx vitest run` — 108/108 passing (39 in `lib/suspension/model.test.ts`, including the `computeScrubRadius` bridge at zero/positive/negative inputs, KPI sign-flip symmetry, the closed-form combined input, wheel-center perpendicular offset, no-camber-impact invariant, and a tire-OD linearity check on trail)
- [x] Vercel preview: hex/offset shift the rim 1:1 in rear view; tire OD scales the wheel rectangle in both views; scrub readout responds correctly; existing camber/caster/toe behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)