### PR TITLE
feat: suspension tool — state sliders, live readouts & ghost (#84)

### DIFF
--- a/components/suspension/ReadoutPanel.tsx
+++ b/components/suspension/ReadoutPanel.tsx
@@ -59,6 +59,38 @@ export default function ReadoutPanel({ geometry }: Props) {
           {geometry.maxSteeringLock.reason}
         </p>
       )}
+
+      {!geometry.isStateNeutral && (
+        <>
+          <p
+            className="mb-3 mt-6 font-mono text-xs uppercase tracking-[0.2em]"
+            style={{ color: 'var(--muted)' }}
+          >
+            Live
+          </p>
+          <PairedReadout
+            label="Camber"
+            unit="°"
+            left={geometry.live.left.rear.camberDeg}
+            right={geometry.live.right.rear.camberDeg}
+            precision={PRECISION.angleDeg}
+          />
+          <PairedReadout
+            label="Toe"
+            unit="°"
+            left={geometry.live.left.top.toeDeg}
+            right={geometry.live.right.top.toeDeg}
+            precision={PRECISION.angleDeg}
+          />
+          <PairedReadout
+            label="Scrub"
+            unit=" mm"
+            left={geometry.live.left.scrubRadiusMm}
+            right={geometry.live.right.scrubRadiusMm}
+            precision={PRECISION.lengthMm}
+          />
+        </>
+      )}
     </div>
   )
 }
@@ -72,6 +104,32 @@ function Readout({ label, value }: { label: string; value: string }) {
       <span className="font-mono text-sm tabular-nums" style={{ color: 'var(--foreground)' }}>
         {value}
       </span>
+    </div>
+  )
+}
+
+function PairedReadout({
+  label,
+  unit,
+  left,
+  right,
+  precision,
+}: {
+  label: string
+  unit: string
+  left: number
+  right: number
+  precision: number
+}) {
+  return (
+    <div className="mb-3">
+      <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--muted)' }}>
+        {label}
+      </span>
+      <div className="mt-0.5 grid grid-cols-2 gap-2 font-mono text-sm tabular-nums" style={{ color: 'var(--foreground)' }}>
+        <span>L {left.toFixed(precision)}{unit}</span>
+        <span>R {right.toFixed(precision)}{unit}</span>
+      </div>
     </div>
   )
 }

--- a/components/suspension/RearView.tsx
+++ b/components/suspension/RearView.tsx
@@ -1,4 +1,4 @@
-import type { Geometry } from '@/lib/suspension/model'
+import type { Geometry, RearGeometry } from '@/lib/suspension/model'
 
 const VIEW_WIDTH = 320
 const VIEW_HEIGHT = 130
@@ -8,14 +8,15 @@ const STEERING_RED = '#FF0020'
 
 type Props = {
   geometry: Geometry
+  showGhost?: boolean
 }
 
-export default function RearView({ geometry }: Props) {
-  const { rear, chassis, setup } = geometry
-
-  // Right side as computed; left side is mirrored across the chassis centerline.
-  const right = rear
-  const left = mirrorRear(rear)
+export default function RearView({ geometry, showGhost = true }: Props) {
+  const { live, isStateNeutral, chassis, setup } = geometry
+  const right = live.right.rear
+  const left = live.left.rear
+  const ghost = showGhost && !isStateNeutral
+  const restingLeft = mirrorRear(geometry.rear)
 
   return (
     <svg
@@ -57,6 +58,14 @@ export default function RearView({ geometry }: Props) {
           strokeWidth="1"
           strokeDasharray="4 3"
         />
+
+        {/* Ghost (resting) — wheel outline + kingpin axis only, behind live geometry */}
+        {ghost && (
+          <>
+            <Ghost rear={geometry.rear} tireOD={setup.tireOD} tireWidth={chassis.tireWidth} />
+            <Ghost rear={restingLeft} tireOD={setup.tireOD} tireWidth={chassis.tireWidth} />
+          </>
+        )}
 
         {/* Lower arms */}
         <line
@@ -214,11 +223,50 @@ function Wheel({
   )
 }
 
+function Ghost({
+  rear,
+  tireOD,
+  tireWidth,
+}: {
+  rear: RearGeometry
+  tireOD: number
+  tireWidth: number
+}) {
+  // PRD ghost: wheel outline + kingpin axis only, foreground at 30%, 1.5px solid.
+  const sign = rear.wheelCenter.x >= 0 ? -1 : 1
+  const transform = `rotate(${sign * rear.camberDeg} ${rear.wheelCenter.x} ${rear.wheelCenter.y})`
+  return (
+    <g opacity="0.3">
+      <line
+        x1={rear.lowerOutboard.x}
+        y1={rear.lowerOutboard.y}
+        x2={rear.upperOutboard.x}
+        y2={rear.upperOutboard.y}
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <g transform={transform}>
+        <rect
+          x={rear.wheelCenter.x - tireWidth / 2}
+          y={rear.wheelCenter.y - tireOD / 2}
+          width={tireWidth}
+          height={tireOD}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          rx="2"
+        />
+      </g>
+    </g>
+  )
+}
+
 function Pivot({ x, y }: { x: number; y: number }) {
   return <circle cx={x} cy={y} r={2} fill="currentColor" />
 }
 
-function mirrorRear(rear: Geometry['rear']): Geometry['rear'] {
+function mirrorRear(rear: RearGeometry): RearGeometry {
   return {
     lowerInboard: { x: -rear.lowerInboard.x, y: rear.lowerInboard.y },
     lowerOutboard: { x: -rear.lowerOutboard.x, y: rear.lowerOutboard.y },

--- a/components/suspension/StatePanel.tsx
+++ b/components/suspension/StatePanel.tsx
@@ -1,19 +1,118 @@
-// Stub for the state slider region (steering input, L/R wheel travel).
-// State sliders land in #84; this placeholder keeps the responsive shell
-// honest by reserving the bottom-docked region across all breakpoints.
+'use client'
 
-export default function StatePanel() {
+import { STEERING_INPUT, WHEEL_TRAVEL } from '@/lib/suspension/config'
+
+type Props = {
+  steeringInput: number
+  onSteeringInputChange: (value: number) => void
+  leftWheelTravelMm: number
+  onLeftWheelTravelChange: (value: number) => void
+  rightWheelTravelMm: number
+  onRightWheelTravelChange: (value: number) => void
+  showGhost: boolean
+  onShowGhostChange: (value: boolean) => void
+  isStateNeutral: boolean
+}
+
+export default function StatePanel({
+  steeringInput,
+  onSteeringInputChange,
+  leftWheelTravelMm,
+  onLeftWheelTravelChange,
+  rightWheelTravelMm,
+  onRightWheelTravelChange,
+  showGhost,
+  onShowGhostChange,
+  isStateNeutral,
+}: Props) {
   return (
     <div
       className="w-full rounded-lg border p-3"
       style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
     >
-      <p className="font-mono text-xs uppercase tracking-[0.2em]" style={{ color: 'var(--muted)' }}>
-        State
-      </p>
-      <p className="mt-1 text-xs" style={{ color: 'var(--muted)' }}>
-        Steering & travel sliders coming in a later slice.
-      </p>
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <p className="font-mono text-xs uppercase tracking-[0.2em]" style={{ color: 'var(--muted)' }}>
+          State
+        </p>
+        <label
+          className="flex items-center gap-1.5 font-mono text-xs"
+          style={{ color: isStateNeutral ? 'var(--muted)' : 'var(--foreground)' }}
+        >
+          <input
+            type="checkbox"
+            checked={showGhost}
+            disabled={isStateNeutral}
+            onChange={e => onShowGhostChange(e.target.checked)}
+            style={{ accentColor: '#FF0020' }}
+          />
+          Ghost
+        </label>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <ScrubSlider
+          label="Steering"
+          value={steeringInput}
+          min={STEERING_INPUT.min}
+          max={STEERING_INPUT.max}
+          step={STEERING_INPUT.step}
+          display={v => `${v >= 0 ? '+' : ''}${v.toFixed(0)}%`}
+          onChange={onSteeringInputChange}
+        />
+        <ScrubSlider
+          label="Travel L"
+          value={leftWheelTravelMm}
+          min={WHEEL_TRAVEL.min}
+          max={WHEEL_TRAVEL.max}
+          step={WHEEL_TRAVEL.step}
+          display={v => `${v >= 0 ? '+' : ''}${v.toFixed(1)} mm`}
+          onChange={onLeftWheelTravelChange}
+        />
+        <ScrubSlider
+          label="Travel R"
+          value={rightWheelTravelMm}
+          min={WHEEL_TRAVEL.min}
+          max={WHEEL_TRAVEL.max}
+          step={WHEEL_TRAVEL.step}
+          display={v => `${v >= 0 ? '+' : ''}${v.toFixed(1)} mm`}
+          onChange={onRightWheelTravelChange}
+        />
+      </div>
+    </div>
+  )
+}
+
+type ScrubSliderProps = {
+  label: string
+  value: number
+  min: number
+  max: number
+  step: number
+  display: (v: number) => string
+  onChange: (v: number) => void
+}
+
+function ScrubSlider({ label, value, min, max, step, display, onChange }: ScrubSliderProps) {
+  return (
+    <div>
+      <div className="mb-1 flex items-baseline justify-between gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--muted)' }}>
+          {label}
+        </span>
+        <span className="font-mono text-xs tabular-nums" style={{ color: 'var(--foreground)' }}>
+          {display(value)}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={e => onChange(parseFloat(e.target.value))}
+        className="w-full"
+        style={{ accentColor: '#FF0020' }}
+      />
     </div>
   )
 }

--- a/components/suspension/SuspensionTool.tsx
+++ b/components/suspension/SuspensionTool.tsx
@@ -12,6 +12,8 @@ import {
   CARRIER_HEIGHT,
   CARRIER_TIE_ROD_INBOARD_OFFSET,
   STEERING_RACK_FORE_AFT,
+  STEERING_INPUT,
+  WHEEL_TRAVEL,
   type RackType,
 } from '@/lib/suspension/config'
 import { computeGeometry } from '@/lib/suspension/model'
@@ -34,21 +36,35 @@ export default function SuspensionTool() {
   const [carrierHeightMm, setCarrierHeightMm] = useState(CARRIER_HEIGHT.defaultValue)
   const [steeringRackType, setSteeringRackType] = useState<RackType>('direct-drive')
 
+  // State sliders — never persist; useState defaults guarantee neutral on every page load.
+  const [steeringInput, setSteeringInput] = useState(STEERING_INPUT.defaultValue)
+  const [leftWheelTravelMm, setLeftWheelTravelMm] = useState(WHEEL_TRAVEL.defaultValue)
+  const [rightWheelTravelMm, setRightWheelTravelMm] = useState(WHEEL_TRAVEL.defaultValue)
+  const [showGhost, setShowGhost] = useState(true)
+
   const geometry = useMemo(
     () =>
-      computeGeometry({
-        lowerArmLength,
-        tieRodLength,
-        casterSpacerDeg,
-        upperArmLength,
-        wheelHexThicknessMm,
-        wheelOffsetMm,
-        tireOD,
-        carrierTieRodInboardOffsetMm,
-        steeringRackForeAftMm,
-        carrierHeightMm,
-        steeringRackType,
-      }),
+      computeGeometry(
+        {
+          lowerArmLength,
+          tieRodLength,
+          casterSpacerDeg,
+          upperArmLength,
+          wheelHexThicknessMm,
+          wheelOffsetMm,
+          tireOD,
+          carrierTieRodInboardOffsetMm,
+          steeringRackForeAftMm,
+          carrierHeightMm,
+          steeringRackType,
+        },
+        undefined,
+        {
+          steeringInput,
+          leftWheelTravelMm,
+          rightWheelTravelMm,
+        },
+      ),
     [
       lowerArmLength,
       tieRodLength,
@@ -61,6 +77,9 @@ export default function SuspensionTool() {
       steeringRackForeAftMm,
       carrierHeightMm,
       steeringRackType,
+      steeringInput,
+      leftWheelTravelMm,
+      rightWheelTravelMm,
     ],
   )
 
@@ -109,7 +128,7 @@ export default function SuspensionTool() {
                 </p>
               </div>
               <div className="aspect-[16/10] w-full" style={{ color: 'var(--foreground)' }}>
-                <TopView geometry={geometry} />
+                <TopView geometry={geometry} showGhost={showGhost} />
               </div>
             </div>
 
@@ -123,7 +142,7 @@ export default function SuspensionTool() {
                 </p>
               </div>
               <div className="aspect-[16/7] w-full" style={{ color: 'var(--foreground)' }}>
-                <RearView geometry={geometry} />
+                <RearView geometry={geometry} showGhost={showGhost} />
               </div>
             </div>
           </div>
@@ -132,7 +151,17 @@ export default function SuspensionTool() {
         </div>
 
         <div className="mt-4">
-          <StatePanel />
+          <StatePanel
+            steeringInput={steeringInput}
+            onSteeringInputChange={setSteeringInput}
+            leftWheelTravelMm={leftWheelTravelMm}
+            onLeftWheelTravelChange={setLeftWheelTravelMm}
+            rightWheelTravelMm={rightWheelTravelMm}
+            onRightWheelTravelChange={setRightWheelTravelMm}
+            showGhost={showGhost}
+            onShowGhostChange={setShowGhost}
+            isStateNeutral={geometry.isStateNeutral}
+          />
         </div>
       </div>
     </section>

--- a/components/suspension/TopView.tsx
+++ b/components/suspension/TopView.tsx
@@ -1,4 +1,4 @@
-import type { Geometry } from '@/lib/suspension/model'
+import type { Geometry, SideTopGeometry } from '@/lib/suspension/model'
 
 const VIEW_WIDTH = 320
 const VIEW_HEIGHT = 200
@@ -7,31 +7,27 @@ const VIEW_Y_MIN = -VIEW_HEIGHT / 2
 
 type Props = {
   geometry: Geometry
+  showGhost?: boolean
 }
 
 const STEERING_RED = '#FF0020'
 
-export default function TopView({ geometry }: Props) {
-  const { top, chassis, setup } = geometry
-
-  const right = {
-    lowerInboard: top.lowerInboard,
-    lowerOutboard: top.lowerOutboard,
-    upperInboard: top.upperInboard,
-    upperOutboard: top.upperOutboard,
-    wheelCenter: top.wheelCenter,
-    rackBall: top.rackBall,
-    tieRodOutboard: top.tieRodOutboard,
+export default function TopView({ geometry, showGhost = true }: Props) {
+  const { live, isStateNeutral, chassis, setup } = geometry
+  const right = live.right.top
+  const left = live.left.top
+  const ghost = showGhost && !isStateNeutral
+  const restingRight: SideTopGeometry = {
+    lowerInboard: geometry.top.lowerInboard,
+    lowerOutboard: geometry.top.lowerOutboard,
+    upperInboard: geometry.top.upperInboard,
+    upperOutboard: geometry.top.upperOutboard,
+    wheelCenter: geometry.top.wheelCenter,
+    rackBall: geometry.top.rackBall,
+    tieRodOutboard: geometry.top.tieRodOutboard,
+    toeDeg: geometry.top.toeDegRight,
   }
-  const left = {
-    lowerInboard: mirrorX(top.lowerInboard),
-    lowerOutboard: mirrorX(top.lowerOutboard),
-    upperInboard: mirrorX(top.upperInboard),
-    upperOutboard: mirrorX(top.upperOutboard),
-    wheelCenter: mirrorX(top.wheelCenter),
-    rackBall: mirrorX(top.rackBall),
-    tieRodOutboard: mirrorX(top.tieRodOutboard),
-  }
+  const restingLeft = mirrorTop(geometry.top)
 
   // SVG y is flipped relative to math y (+ y math = forward). Group flip lets
   // children use math coords directly so visual "forward" stays at the top.
@@ -55,6 +51,24 @@ export default function TopView({ geometry }: Props) {
           strokeWidth="1"
           strokeDasharray="4 3"
         />
+
+        {/* Ghost (resting) — wheel outline + kingpin axis only, behind live geometry */}
+        {ghost && (
+          <>
+            <Ghost
+              top={restingRight}
+              tireOD={setup.tireOD}
+              tireWidth={chassis.tireWidth}
+              toeSign={1}
+            />
+            <Ghost
+              top={restingLeft}
+              tireOD={setup.tireOD}
+              tireWidth={chassis.tireWidth}
+              toeSign={-1}
+            />
+          </>
+        )}
 
         {/* Lower arms (top-down projection — purely lateral in v1) */}
         <line
@@ -122,7 +136,7 @@ export default function TopView({ geometry }: Props) {
           strokeLinecap="round"
         />
 
-        {/* Wheel footprints — rotated by toe so steering changes are visible.
+        {/* Wheel footprints — rotated by per-side toe so steering changes are visible.
             Sign flips per side so positive toe (toe in) tilts both wheel fronts
             toward the chassis centerline. */}
         <Wheel
@@ -131,7 +145,7 @@ export default function TopView({ geometry }: Props) {
           tireOD={setup.tireOD}
           rimWidth={chassis.rimWidth}
           rimOD={chassis.rimDiameter}
-          toeDeg={top.toeDegRight}
+          toeDeg={right.toeDeg}
         />
         <Wheel
           center={left.wheelCenter}
@@ -139,7 +153,7 @@ export default function TopView({ geometry }: Props) {
           tireOD={setup.tireOD}
           rimWidth={chassis.rimWidth}
           rimOD={chassis.rimDiameter}
-          toeDeg={-top.toeDegLeft}
+          toeDeg={-left.toeDeg}
         />
 
         {/* Steering rack — connects the two rack balls laterally */}
@@ -238,10 +252,63 @@ function Wheel({
   )
 }
 
+// Top-view ghost: wheel outline (tire only, rotated by static toe) + the
+// kingpin segment from lowerOutboard to upperOutboard. PRD spec: foreground
+// at 30%, 1.5px solid.
+function Ghost({
+  top,
+  tireOD,
+  tireWidth,
+  toeSign,
+}: {
+  top: SideTopGeometry
+  tireOD: number
+  tireWidth: number
+  toeSign: 1 | -1
+}) {
+  const transform = `rotate(${toeSign * top.toeDeg} ${top.wheelCenter.x} ${top.wheelCenter.y})`
+  return (
+    <g opacity="0.3">
+      <line
+        x1={top.lowerOutboard.x}
+        y1={top.lowerOutboard.y}
+        x2={top.upperOutboard.x}
+        y2={top.upperOutboard.y}
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <g transform={transform}>
+        <rect
+          x={top.wheelCenter.x - tireWidth / 2}
+          y={top.wheelCenter.y - tireOD / 2}
+          width={tireWidth}
+          height={tireOD}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          rx="2"
+        />
+      </g>
+    </g>
+  )
+}
+
 function Pivot({ x, y }: { x: number; y: number }) {
   return <circle cx={x} cy={y} r={2} fill="currentColor" />
 }
 
-function mirrorX(p: { x: number; y: number }) {
-  return { x: -p.x, y: p.y }
+function mirrorTop(top: Geometry['top']): SideTopGeometry {
+  // Geometry.top is the right-side resting top; mirror it across the chassis
+  // centerline so the ghost can render the left-side resting wheel position.
+  return {
+    lowerInboard: { x: -top.lowerInboard.x, y: top.lowerInboard.y },
+    lowerOutboard: { x: -top.lowerOutboard.x, y: top.lowerOutboard.y },
+    upperInboard: { x: -top.upperInboard.x, y: top.upperInboard.y },
+    upperOutboard: { x: -top.upperOutboard.x, y: top.upperOutboard.y },
+    wheelCenter: { x: -top.wheelCenter.x, y: top.wheelCenter.y },
+    rackBall: { x: -top.rackBall.x, y: top.rackBall.y },
+    tieRodOutboard: { x: -top.tieRodOutboard.x, y: top.tieRodOutboard.y },
+    toeDeg: top.toeDegLeft,
+  }
 }

--- a/lib/suspension/config.ts
+++ b/lib/suspension/config.ts
@@ -63,6 +63,12 @@ export const TIRE_OD: SliderDef = { min: 50, max: 70, step: 0.5, defaultValue: 6
 // lower kingpin ball. Default = knuckleLength/2 (hub at midpoint).
 export const CARRIER_HEIGHT: SliderDef = { min: 10, max: 35, step: 0.5, defaultValue: 22.5 }
 
+// Ephemeral car articulation — never persists, resets on every page load.
+// Steering input scales the rack lateral travel (100% = full lock); wheel
+// travel is bump (positive) or droop (negative) from ride height per side.
+export const STEERING_INPUT: SliderDef = { min: -100, max: 100, step: 1, defaultValue: 0 }
+export const WHEEL_TRAVEL: SliderDef = { min: -10, max: 10, step: 0.5, defaultValue: 0 }
+
 // Chassis baseline. Engineered so that at default LOWER_ARM_LENGTH the kingpin is
 // vertical (camber = 0°) and the wheel sits with its bottom at ground.
 export const CHASSIS_BASELINE: ChassisBaseline = {

--- a/lib/suspension/model.test.ts
+++ b/lib/suspension/model.test.ts
@@ -5,8 +5,9 @@ import {
   computeScrubRadius,
   computeAckermanDelta,
   computeMaxSteeringLock,
+  NEUTRAL_STATE,
 } from './model'
-import type { SteeringSnapshot } from './model'
+import type { SteeringSnapshot, State } from './model'
 import {
   CHASSIS_BASELINE,
   LOWER_ARM_LENGTH,
@@ -523,5 +524,190 @@ describe('computeGeometry — robustness', () => {
         expect(Number.isFinite(geo.rear.wheelCenter.y)).toBe(true)
       }
     }
+  })
+})
+
+describe('computeGeometry — state-aware live geometry', () => {
+  it('reports neutral state and live values matching static geometry when no state is passed', () => {
+    const geo = computeGeometry({ ...DEFAULTS })
+    expect(geo.isStateNeutral).toBe(true)
+    expect(geo.state).toEqual(NEUTRAL_STATE)
+    // Live right-side rear matches the static (right-side-frame) rear.
+    expect(geo.live.right.rear.camberDeg).toBeCloseTo(geo.rear.camberDeg, 9)
+    expect(geo.live.right.rear.lowerOutboard.x).toBeCloseTo(geo.rear.lowerOutboard.x, 9)
+    expect(geo.live.right.rear.wheelCenter.x).toBeCloseTo(geo.rear.wheelCenter.x, 9)
+    // Left-side rear is the static rear mirrored across the chassis centerline.
+    expect(geo.live.left.rear.camberDeg).toBeCloseTo(geo.rear.camberDeg, 9)
+    expect(geo.live.left.rear.wheelCenter.x).toBeCloseTo(-geo.rear.wheelCenter.x, 9)
+    // Live toe is mirror-equal to the static value at neutral state.
+    expect(geo.live.right.top.toeDeg).toBeCloseTo(geo.top.toeDegRight, 9)
+    expect(geo.live.left.top.toeDeg).toBeCloseTo(geo.top.toeDegLeft, 9)
+  })
+
+  it('reports neutral when an explicit neutral state is passed', () => {
+    const geo = computeGeometry({ ...DEFAULTS }, undefined, NEUTRAL_STATE)
+    expect(geo.isStateNeutral).toBe(true)
+  })
+
+  it('reports non-neutral when any state slider leaves zero', () => {
+    const steered = computeGeometry({ ...DEFAULTS }, undefined, { ...NEUTRAL_STATE, steeringInput: 25 })
+    expect(steered.isStateNeutral).toBe(false)
+    const bumped = computeGeometry({ ...DEFAULTS }, undefined, { ...NEUTRAL_STATE, leftWheelTravelMm: 2 })
+    expect(bumped.isStateNeutral).toBe(false)
+    const droopedR = computeGeometry({ ...DEFAULTS }, undefined, { ...NEUTRAL_STATE, rightWheelTravelMm: -3 })
+    expect(droopedR.isStateNeutral).toBe(false)
+  })
+})
+
+describe('computeGeometry — live camber & scrub from wheel travel', () => {
+  // The default CHASSIS_BASELINE is a degenerate parallelogram (lower arm =
+  // upper arm = knuckle = chassisHeight = 45), which produces ~zero camber
+  // gain on bump. Camber-gain assertions need a non-parallelogram chassis.
+  const CAMBER_GAIN_CHASSIS: ChassisBaseline = {
+    ...CHASSIS_BASELINE,
+    knuckleLength: 50,
+  }
+
+  it('drives the bumped side camber away from static while the unbumped side holds', () => {
+    const baseline = computeGeometry({ ...DEFAULTS }, CAMBER_GAIN_CHASSIS)
+    const geo = computeGeometry({ ...DEFAULTS }, CAMBER_GAIN_CHASSIS, {
+      ...NEUTRAL_STATE,
+      rightWheelTravelMm: 5,
+    })
+    expect(Math.abs(geo.live.right.rear.camberDeg - baseline.rear.camberDeg)).toBeGreaterThan(0.1)
+    expect(geo.live.left.rear.camberDeg).toBeCloseTo(baseline.rear.camberDeg, 9)
+  })
+
+  it('moves bump and droop in opposite camber directions on the same side', () => {
+    const baseline = computeGeometry({ ...DEFAULTS }, CAMBER_GAIN_CHASSIS)
+    const bump = computeGeometry({ ...DEFAULTS }, CAMBER_GAIN_CHASSIS, {
+      ...NEUTRAL_STATE,
+      leftWheelTravelMm: 5,
+    })
+    const droop = computeGeometry({ ...DEFAULTS }, CAMBER_GAIN_CHASSIS, {
+      ...NEUTRAL_STATE,
+      leftWheelTravelMm: -5,
+    })
+    const bumpDelta = bump.live.left.rear.camberDeg - baseline.rear.camberDeg
+    const droopDelta = droop.live.left.rear.camberDeg - baseline.rear.camberDeg
+    expect(Math.sign(bumpDelta)).not.toBe(Math.sign(droopDelta))
+  })
+
+  it('shifts live scrub radius per side when that side articulates (KPI changes with travel)', () => {
+    // Use a non-zero hex so the scrub readout is sensitive to KPI changes.
+    const setup = { ...DEFAULTS, wheelHexThicknessMm: 5 }
+    const baseline = computeGeometry(setup, CAMBER_GAIN_CHASSIS)
+    const geo = computeGeometry(setup, CAMBER_GAIN_CHASSIS, {
+      ...NEUTRAL_STATE,
+      leftWheelTravelMm: 5,
+    })
+    expect(Math.abs(geo.live.left.scrubRadiusMm - baseline.scrubRadiusMm)).toBeGreaterThan(0.1)
+    expect(geo.live.right.scrubRadiusMm).toBeCloseTo(baseline.scrubRadiusMm, 9)
+  })
+
+  it('keeps live KPI consistent with -camber on the articulated side', () => {
+    const geo = computeGeometry({ ...DEFAULTS }, CAMBER_GAIN_CHASSIS, {
+      ...NEUTRAL_STATE,
+      rightWheelTravelMm: 4,
+    })
+    expect(geo.live.right.rear.kpiDeg).toBeCloseTo(-geo.live.right.rear.camberDeg, 6)
+  })
+})
+
+describe('computeGeometry — live toe under steering input', () => {
+  // Steering at 50% leaves the linkage well inside its reach envelope on both
+  // sides without landing on the algebraic singularity that occurs at full
+  // lock when rack-to-baseline distance happens to equal the tie rod length.
+  const STEERING_INPUT_50 = 50
+
+  it('drives left and right toe to opposite signs at non-zero steering', () => {
+    const geo = computeGeometry({ ...DEFAULTS }, undefined, {
+      ...NEUTRAL_STATE,
+      steeringInput: STEERING_INPUT_50,
+    })
+    expect(geo.live.right.top.toeDeg).not.toBeCloseTo(geo.live.left.top.toeDeg, 1)
+    // Steering produces opposite-sign rotations on the two sides under the
+    // "+ = toe in for this side" convention used by the live readouts.
+    expect(Math.sign(geo.live.right.top.toeDeg)).not.toBe(Math.sign(geo.live.left.top.toeDeg))
+  })
+
+  it('flips both per-side toe signs when steering input flips sign', () => {
+    const positive = computeGeometry({ ...DEFAULTS }, undefined, {
+      ...NEUTRAL_STATE,
+      steeringInput: STEERING_INPUT_50,
+    })
+    const negative = computeGeometry({ ...DEFAULTS }, undefined, {
+      ...NEUTRAL_STATE,
+      steeringInput: -STEERING_INPUT_50,
+    })
+    expect(Math.sign(positive.live.right.top.toeDeg)).not.toBe(
+      Math.sign(negative.live.right.top.toeDeg),
+    )
+    expect(Math.sign(positive.live.left.top.toeDeg)).not.toBe(
+      Math.sign(negative.live.left.top.toeDeg),
+    )
+  })
+
+  it('produces zero per-side toe deltas at zero steering and neutral travel', () => {
+    const geo = computeGeometry({ ...DEFAULTS }, undefined, NEUTRAL_STATE)
+    expect(geo.live.right.top.toeDeg).toBeCloseTo(geo.top.toeDegRight, 9)
+    expect(geo.live.left.top.toeDeg).toBeCloseTo(geo.top.toeDegLeft, 9)
+  })
+
+  it('moves the live rack ball laterally by steering·effectiveRackTravel/100', () => {
+    // Direct drive: effective rack travel = chassis maxRackTravelMm.
+    const geo = computeGeometry({ ...DEFAULTS }, undefined, { ...NEUTRAL_STATE, steeringInput: 100 })
+    const expectedShift = CHASSIS_BASELINE.maxRackTravelMm
+    // Right rack ball in chassis frame: chassis.rackBallX + shift (positive +x).
+    expect(geo.live.right.top.rackBall.x).toBeCloseTo(CHASSIS_BASELINE.rackBallX + expectedShift, 6)
+    // Left rack ball in chassis frame: −chassis.rackBallX + shift (rack moves
+    // uniformly in chassis +x — both balls shift together).
+    expect(geo.live.left.top.rackBall.x).toBeCloseTo(-CHASSIS_BASELINE.rackBallX + expectedShift, 6)
+  })
+
+  it('scales rack-ball shift by the rack-type effective-travel factor (wiper × 0.9)', () => {
+    const direct = computeGeometry({ ...DEFAULTS }, undefined, { ...NEUTRAL_STATE, steeringInput: 100 })
+    const wiper = computeGeometry({ ...DEFAULTS, steeringRackType: 'wiper' }, undefined, {
+      ...NEUTRAL_STATE,
+      steeringInput: 100,
+    })
+    const directShift = direct.live.right.top.rackBall.x - CHASSIS_BASELINE.rackBallX
+    const wiperShift = wiper.live.right.top.rackBall.x - CHASSIS_BASELINE.rackBallX
+    expect(wiperShift / directShift).toBeCloseTo(0.9, 6)
+  })
+})
+
+describe('computeGeometry — combined state', () => {
+  it('produces finite per-side outputs across combined steering + L/R travel', () => {
+    const cases: State[] = [
+      { steeringInput: 50, leftWheelTravelMm: 3, rightWheelTravelMm: -3 },
+      { steeringInput: -75, leftWheelTravelMm: -5, rightWheelTravelMm: 5 },
+      { steeringInput: 25, leftWheelTravelMm: 8, rightWheelTravelMm: 8 },
+      { steeringInput: -25, leftWheelTravelMm: -8, rightWheelTravelMm: -8 },
+    ]
+    for (const state of cases) {
+      const geo = computeGeometry({ ...DEFAULTS }, undefined, state)
+      for (const side of [geo.live.left, geo.live.right]) {
+        expect(Number.isFinite(side.rear.camberDeg)).toBe(true)
+        expect(Number.isFinite(side.rear.kpiDeg)).toBe(true)
+        expect(Number.isFinite(side.top.toeDeg)).toBe(true)
+        expect(Number.isFinite(side.scrubRadiusMm)).toBe(true)
+        expect(Number.isFinite(side.top.wheelCenter.x)).toBe(true)
+        expect(Number.isFinite(side.top.tieRodOutboard.x)).toBe(true)
+      }
+    }
+  })
+
+  it('does not mutate static readouts when state changes', () => {
+    const baseline = computeGeometry({ ...DEFAULTS })
+    const stated = computeGeometry({ ...DEFAULTS }, undefined, {
+      steeringInput: 50,
+      leftWheelTravelMm: 4,
+      rightWheelTravelMm: -2,
+    })
+    expect(stated.rear.camberDeg).toBeCloseTo(baseline.rear.camberDeg, 9)
+    expect(stated.top.toeDegRight).toBeCloseTo(baseline.top.toeDegRight, 9)
+    expect(stated.scrubRadiusMm).toBeCloseTo(baseline.scrubRadiusMm, 9)
+    expect(stated.ackermanDeltaDeg).toBeCloseTo(baseline.ackermanDeltaDeg, 9)
   })
 })

--- a/lib/suspension/model.ts
+++ b/lib/suspension/model.ts
@@ -41,11 +41,46 @@ export type TopGeometry = {
   wheelCenter: Point
   rackBall: Point        // right-side rack ball
   tieRodOutboard: Point  // right-side tie rod outboard attach (knuckle pickup)
-  // Toe per side, signed: positive = toe in (front of wheel toward chassis centerline).
-  // Equal under mirror-symmetric setup with no steering input; diverge once
-  // the steering state slider lands in #84.
+  // Static toe (resting state) — positive = toe in. Per side at the data layer
+  // because the live `Geometry.live` per-side readouts diverge under steering;
+  // the static pair is mirror-equal, exposed as L/R for renderer symmetry.
   toeDegRight: number
   toeDegLeft: number
+}
+
+// Ephemeral car articulation — never persists, resets on every page load.
+// Steering input drives top-view rack offset; wheel travel drives per-side
+// rear-view lower-arm rotation. Range bounds live in `config.ts`.
+export type State = {
+  steeringInput: number          // -100 to +100; percent of effective rack travel
+  leftWheelTravelMm: number      // signed bump (positive) / droop (negative) from ride height
+  rightWheelTravelMm: number
+}
+
+export const NEUTRAL_STATE: State = {
+  steeringInput: 0,
+  leftWheelTravelMm: 0,
+  rightWheelTravelMm: 0,
+}
+
+export type SideTopGeometry = {
+  lowerInboard: Point
+  lowerOutboard: Point
+  upperInboard: Point
+  upperOutboard: Point
+  wheelCenter: Point
+  rackBall: Point
+  tieRodOutboard: Point
+  toeDeg: number   // signed; positive = toe in for this side
+}
+
+// Per-side live geometry in chassis frame (right at +x, left at -x). Renderer
+// uses these directly — no further mirroring. Equal to the resting geometry
+// (within mirror-symmetry) when the state is neutral.
+export type SideGeometry = {
+  rear: RearGeometry
+  top: SideTopGeometry
+  scrubRadiusMm: number
 }
 
 export type MaxSteeringLockResult = {
@@ -55,6 +90,8 @@ export type MaxSteeringLockResult = {
 }
 
 export type Geometry = {
+  // Resting (state-neutral, mirror-symmetric) geometry — drives static readouts
+  // and the ghost overlay.
   rear: RearGeometry
   top: TopGeometry
   chassis: ChassisBaseline   // exposed so renderers can size wheels, rims, etc.
@@ -64,6 +101,10 @@ export type Geometry = {
   scrubRadiusMm: number      // signed: positive = wheel contact outboard of kingpin axis at ground
   ackermanDeltaDeg: number   // |inner| − |outer| at full lock; 0° = parallel, positive = inner turns more
   maxSteeringLock: MaxSteeringLockResult
+  // State-aware live geometry — renderer reads these for the articulated wireframe.
+  state: State
+  isStateNeutral: boolean
+  live: { left: SideGeometry; right: SideGeometry }
 }
 
 // Intersect two circles in 2D. Returns the intersection point on the side
@@ -101,11 +142,22 @@ function circleCircleIntersect(
   return p1.x <= p2.x ? p1 : p2
 }
 
-function computeRearGeometry(setup: Setup, chassis: ChassisBaseline): RearGeometry {
+function computeRearGeometry(
+  setup: Setup,
+  chassis: ChassisBaseline,
+  travelMm: number = 0,
+): RearGeometry {
   const lowerInboard: Point = { x: chassis.blockLowerInboardX, y: chassis.blockLowerY }
   const upperInboard: Point = { x: chassis.blockUpperInboardX, y: chassis.blockUpperY }
 
-  const armAngleRad = (chassis.staticLowerArmAngleDeg * Math.PI) / 180
+  // Travel raises (bump, +) or drops (droop, −) the outboard end of the lower
+  // arm by travelMm. The arm length is fixed, so the new arm angle satisfies
+  //   L·sin(θ_new) = L·sin(θ_static) + travelMm
+  // Clamp to avoid asin domain blowup at extreme over-bump (proper
+  // GeometryError lands in #86).
+  const baseAngleRad = (chassis.staticLowerArmAngleDeg * Math.PI) / 180
+  const sinTarget = Math.sin(baseAngleRad) + travelMm / setup.lowerArmLength
+  const armAngleRad = Math.asin(Math.max(-0.999, Math.min(0.999, sinTarget)))
   const lowerOutboard: Point = {
     x: lowerInboard.x + setup.lowerArmLength * Math.cos(armAngleRad),
     y: lowerInboard.y + setup.lowerArmLength * Math.sin(armAngleRad),
@@ -185,11 +237,16 @@ function intersectClosestToBaseline(
   return d1 <= d2 ? p1 : p2
 }
 
-function computeTopGeometry(
+// Per-side top geometry in right-side-relative frame (positive x = outboard
+// for that side). `rackOffsetMm` is the lateral shift of the rack ball in the
+// same frame — for the right side this equals the chassis-frame steering
+// shift; for the left side it flips sign because the left frame is mirrored.
+function computeRightSideTopGeometry(
   setup: Setup,
-  rear: RearGeometry,
   chassis: ChassisBaseline,
-): TopGeometry {
+  rear: RearGeometry,
+  rackOffsetMm: number = 0,
+): SideTopGeometry {
   // v1 top-view collapse: the kingpin axis projects to a single point at the
   // midpoint of the two kingpin balls — distinct from the wheel center once
   // wheel offset displaces the rim laterally (#82). The knuckle's tie rod
@@ -204,9 +261,10 @@ function computeTopGeometry(
     x: kingpin.x + chassis.knuckleTieRodOffsetX - setup.carrierTieRodInboardOffsetMm,
     y: kingpin.y + chassis.knuckleTieRodOffsetY,
   }
-  // Steering rack fore/aft slides the entire rack along the chassis longitudinal axis.
+  // Steering rack fore/aft slides the rack along the chassis longitudinal
+  // axis; steering input shifts it laterally by `rackOffsetMm`.
   const rackBall: Point = {
-    x: chassis.rackBallX,
+    x: chassis.rackBallX + rackOffsetMm,
     y: chassis.rackBallY + setup.steeringRackForeAftMm,
   }
   const knuckleRadius = Math.hypot(
@@ -229,7 +287,7 @@ function computeTopGeometry(
   let rotationRad = currentAngle - baselineAngle
   if (rotationRad > Math.PI) rotationRad -= 2 * Math.PI
   if (rotationRad <= -Math.PI) rotationRad += 2 * Math.PI
-  const toeDegRight = rotationRad * (180 / Math.PI)
+  const toeDeg = rotationRad * (180 / Math.PI)
 
   // Caster spacers shift the entire upper hinge pin fore/aft on the chassis,
   // so both ends of the upper arm translate together and the arm stays
@@ -250,8 +308,79 @@ function computeTopGeometry(
     wheelCenter: { x: rear.wheelCenter.x, y: 0 },
     rackBall,
     tieRodOutboard,
-    toeDegRight,
-    toeDegLeft: toeDegRight,
+    toeDeg,
+  }
+}
+
+function computeTopGeometry(
+  setup: Setup,
+  rear: RearGeometry,
+  chassis: ChassisBaseline,
+): TopGeometry {
+  const right = computeRightSideTopGeometry(setup, chassis, rear, 0)
+  return {
+    lowerInboard: right.lowerInboard,
+    lowerOutboard: right.lowerOutboard,
+    upperInboard: right.upperInboard,
+    upperOutboard: right.upperOutboard,
+    wheelCenter: right.wheelCenter,
+    rackBall: right.rackBall,
+    tieRodOutboard: right.tieRodOutboard,
+    toeDegRight: right.toeDeg,
+    toeDegLeft: right.toeDeg,
+  }
+}
+
+function mirrorRearAcrossX(rear: RearGeometry): RearGeometry {
+  return {
+    lowerInboard: { x: -rear.lowerInboard.x, y: rear.lowerInboard.y },
+    lowerOutboard: { x: -rear.lowerOutboard.x, y: rear.lowerOutboard.y },
+    upperInboard: { x: -rear.upperInboard.x, y: rear.upperInboard.y },
+    upperOutboard: { x: -rear.upperOutboard.x, y: rear.upperOutboard.y },
+    wheelCenter: { x: -rear.wheelCenter.x, y: rear.wheelCenter.y },
+    camberDeg: rear.camberDeg,
+    kpiDeg: rear.kpiDeg,
+  }
+}
+
+function mirrorTopAcrossX(top: SideTopGeometry): SideTopGeometry {
+  return {
+    lowerInboard: { x: -top.lowerInboard.x, y: top.lowerInboard.y },
+    lowerOutboard: { x: -top.lowerOutboard.x, y: top.lowerOutboard.y },
+    upperInboard: { x: -top.upperInboard.x, y: top.upperInboard.y },
+    upperOutboard: { x: -top.upperOutboard.x, y: top.upperOutboard.y },
+    wheelCenter: { x: -top.wheelCenter.x, y: top.wheelCenter.y },
+    rackBall: { x: -top.rackBall.x, y: top.rackBall.y },
+    tieRodOutboard: { x: -top.tieRodOutboard.x, y: top.tieRodOutboard.y },
+    toeDeg: top.toeDeg,   // toe sign is "+ = toe in" per side; mirror preserves it
+  }
+}
+
+function computeSide(
+  setup: Setup,
+  chassis: ChassisBaseline,
+  travelMm: number,
+  rackOffsetMm: number,
+  side: 'left' | 'right',
+): SideGeometry {
+  // For the left side the local rack offset flips sign — a +x chassis-frame
+  // shift becomes −x in the mirrored left frame.
+  const localRackOffset = side === 'right' ? rackOffsetMm : -rackOffsetMm
+  const rear = computeRearGeometry(setup, chassis, travelMm)
+  const top = computeRightSideTopGeometry(setup, chassis, rear, localRackOffset)
+  const scrubRadiusMm = computeScrubRadius(
+    setup.wheelOffsetMm,
+    setup.wheelHexThicknessMm,
+    rear.kpiDeg,
+    setup.tireOD,
+  )
+  if (side === 'right') {
+    return { rear, top, scrubRadiusMm }
+  }
+  return {
+    rear: mirrorRearAcrossX(rear),
+    top: mirrorTopAcrossX(top),
+    scrubRadiusMm,
   }
 }
 
@@ -465,6 +594,7 @@ function buildSteeringSnapshot(
 export function computeGeometry(
   setup: Setup,
   chassis: ChassisBaseline = CHASSIS_BASELINE,
+  state: State = NEUTRAL_STATE,
 ): Geometry {
   const rear = computeRearGeometry(setup, chassis)
   const top = computeTopGeometry(setup, rear, chassis)
@@ -479,6 +609,21 @@ export function computeGeometry(
   const snapshot = buildSteeringSnapshot(setup, rear, top, chassis)
   const ackermanDeltaDeg = computeAckermanDelta(snapshot)
   const maxSteeringLock = computeMaxSteeringLock(snapshot)
+
+  const isStateNeutral =
+    state.steeringInput === 0 &&
+    state.leftWheelTravelMm === 0 &&
+    state.rightWheelTravelMm === 0
+  // Steering input scales the rack lateral travel by the rack-type-effective
+  // limit, so 100% = the maximum the linkage actually delivers.
+  const rackOffsetMm =
+    (state.steeringInput / 100) *
+    effectiveRackTravel(chassis.maxRackTravelMm, setup.steeringRackType)
+  const live = {
+    right: computeSide(setup, chassis, state.rightWheelTravelMm, rackOffsetMm, 'right'),
+    left: computeSide(setup, chassis, state.leftWheelTravelMm, rackOffsetMm, 'left'),
+  }
+
   return {
     rear,
     top,
@@ -489,5 +634,8 @@ export function computeGeometry(
     scrubRadiusMm,
     ackermanDeltaDeg,
     maxSteeringLock,
+    state,
+    isStateNeutral,
+    live,
   }
 }


### PR DESCRIPTION
Closes #84.

## Summary

- Bottom-docked StatePanel: steering input (−100 to +100%), per-side wheel travel (mm), Ghost toggle. State lives in `useState` only — resets to neutral on reload and stays out of any future persistence/export.
- `computeGeometry(setup, chassis, state)` now emits per-side `live: { left, right }` SideGeometry. Steering input scales rack ball laterally by rack-type-effective travel; per-side wheel travel rotates the lower arm so its outboard end translates by the travel amount, with bump steer falling out of the existing 2D math.
- ReadoutPanel grows a Live section (L/R camber, toe, scrub) when state is non-neutral. Wireframes render the live per-side geometry directly and overlay a 30% ghost (wheel outline + kingpin axis) of the resting configuration; toggle disables itself at neutral state.

## Known limitation

With `tieRodLength` tuned so the rack-to-baseline distance equals the tie rod at full lock, `intersectClosestToBaseline` picks the algebraic baseline solution and one wheel reports zero rotation. Not reachable at the default tie rod length. Future slices (#85 bump steer rate / #86 GeometryError) will revisit the linkage solver.

## Test plan

- [ ] `npm run dev`, open `/tools/suspension`
- [ ] Steering input + L/R wheel travel sliders present and start at neutral
- [ ] Reload the page → state returns to neutral
- [ ] Live L/R camber, toe, scrub readouts appear when any state slider is non-neutral; update in real time
- [ ] Steering input animates the top view (both wheels rotate, rack + tie rods translate)
- [ ] L/R wheel travel articulates only that side of the rear view
- [ ] Ghost wireframe (tire outline + kingpin axis @ 30%) renders behind the live geometry; toggle hides/shows; toggle disables at neutral state
- [ ] `npm run build && npm start` and verify on a mobile device for touch behaviour (mobile sticky polish lands in #90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)